### PR TITLE
feat: Added support for RestIot plus

### DIFF
--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -80,7 +80,7 @@ class Hatch:
 
     async def iot_devices(self, auth_token: str):
         url = API_URL + "service/app/iotDevice/v2/fetch"
-        params = {"iotProducts": ["restMini", "restPlus", "riot"]}
+        params = {"iotProducts": ["restMini", "restPlus", "riot", "riotPlus"]}
         response: ClientResponse = (
             await self._get_request_with_logging_and_errors_raised(
                 url=url, auth_token=auth_token, params=params

--- a/src/hatch_rest_api/stub.py
+++ b/src/hatch_rest_api/stub.py
@@ -1,5 +1,6 @@
 # run with "python3 src/hatch_rest_api/stub.py"
 import logging
+import time
 import asyncio
 from threading import Event
 
@@ -12,6 +13,7 @@ sys.path.append(str(path_root))
 from src.hatch_rest_api.util_bootstrap import get_rest_devices
 from src.hatch_rest_api.const import RestPlusAudioTrack
 from src.hatch_rest_api.rest_plus import RestPlus
+from src.hatch_rest_api.riot import RestIot
 import json
 
 logger = logging.getLogger("src.hatch_rest_api")
@@ -34,6 +36,21 @@ async def testing():
         )
 
         for iot_device in iot_devices:
+            if isinstance(iot_device, RestIot):
+
+                def output():
+                    print(f"******-{iot_device}")
+
+                iot_device.register_callback(output)
+
+                print(
+                    "\n\n\n*********** Available favorites on this device *************\n\n\n"
+                )
+                for fav in iot_device.favorite_names():
+                    iot_device.set_favorite(fav)
+                    print(f"\n\n\nPlaying {fav} for 5 seconds\n\n\n")
+                    time.sleep(5)
+
             if isinstance(iot_device, RestPlus):
 
                 def output():

--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -68,7 +68,7 @@ async def get_rest_devices(
                 thing_name=iot_device["thingName"],
                 shadow_client=shadow_client,
             )
-        elif iot_device["product"] == "riot":
+        elif iot_device["product"] in ["riot", "riotPlus"]:
             return RestIot(
                 device_name=iot_device["name"],
                 thing_name=iot_device["thingName"],
@@ -94,7 +94,7 @@ async def get_rest_devices(
 async def _get_favorites_for_all_v2_devices(api, token, iot_devices):
     mac_to_fav = {}
     for device in iot_devices:
-        if device["product"] == "riot":
+        if device["product"] in ["riot", "riotPlus"]:
             mac = device["macAddress"]
             favorites = await api.favorites(auth_token=token, mac=mac)
             _LOGGER.debug(f"Favorites for {mac}: {favorites}")
@@ -105,7 +105,7 @@ async def _get_favorites_for_all_v2_devices(api, token, iot_devices):
 async def _get_sound_content_for_v2_devices(api, token, iot_devices):
     sounds = []
     for device in iot_devices:
-        if device["product"] == "riot" and not sounds:
+        if device["product"] in ["riot", "riotPlus"] and not sounds:
             content = await api.content(
                 auth_token=token, product="riot", content=["sound"]
             )


### PR DESCRIPTION
This is hopefully all that is needed in order to get the 2nd gen plus to work. 

@trevorglaser can you test this by cloning this repo and running `python3 stub.py`?

It will prompt for your username and then password, and it will then loop over all of your stored favorites and play them each for 5 seconds.