### PR TITLE
feat: Refactor riot light logic and remove previous light state cache

### DIFF
--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -60,7 +60,7 @@ async def get_rest_devices(
         mqtt_connection.connect().result()
         _LOGGER.debug(f"mqtt connection connected")
     except Exception as e:
-        _LOGGER.error('MQTT connection failed with exception {}'.format(e))
+        _LOGGER.error(f'MQTT connection failed with exception {e}')
         raise e
 
     shadow_client = IotShadowClient(mqtt_connection)


### PR DESCRIPTION
This is based on conversation over here https://github.com/dahlb/ha_hatch/pull/25

Remove the previous light state cache and move that up to the Home Assistant component code. And refactored the set color logic to move turning off out to its own function.