### PR TITLE
fix: Fix toddler lock and light status on gen 2 devices

### DIFF
--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -117,7 +117,7 @@ class RestIot(ShadowClientSubscriberMixin):
 
     @property
     def is_light_on(self):
-        return self.color_id != 9998
+        return self.color_id != 9998 and self.color_id != 0
 
     @property
     def is_playing(self):

--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -140,10 +140,10 @@ class RestIot(ShadowClientSubscriberMixin):
         _LOGGER.debug(f"Setting volume: {percentage}")
         self._update({"current": {"sound": {"v": convert_from_percentage(percentage)}}})
 
-    # Expected string value for mode is "never" or "always" as hatch defaults to a timed toddler lock so "never" would not automatically turn off the toddler lock.
-    def set_toddler_lock(self, toddler_lock: bool, mode: str):
-        _LOGGER.debug(f"Setting Toddler Lock: toddlerLockOn: {toddler_lock}, toddlerLock.turnOnMode: {mode}")
-        self._update({"toddlerLockOn": toddler_lock})
+    # Expected string value for mode is "never" or "always". The API also supports "custom" for defining a time range
+    def set_toddler_lock(self, on: bool):
+        _LOGGER.debug(f"Setting Toddler On Lock: {on}")
+        mode = "always" if on else "never"
         self._update({"toddlerLock": {"turnOnMode": mode}})
 
     def set_clock(self, flags: int, brightness: int = 0):

--- a/src/hatch_rest_api/stub.py
+++ b/src/hatch_rest_api/stub.py
@@ -48,8 +48,14 @@ async def testing():
                 )
                 for fav in iot_device.favorite_names():
                     iot_device.set_favorite(fav)
-                    print(f"\n\n\nPlaying {fav} for 5 seconds\n\n\n")
-                    time.sleep(5)
+                    print(f"\n\n\nPlaying {fav} for 10 seconds\n\n\n")
+                    time.sleep(10)
+
+                print(f"\n\n\nTurning toddler lock on for 30 seconds")
+                iot_device.set_toddler_lock(True)
+                time.sleep(30)
+                print(f"\n\n\nTurning toddler lock off")
+                iot_device.set_toddler_lock(False)
 
             if isinstance(iot_device, RestPlus):
 


### PR DESCRIPTION
@trevorglaser tested this out from the API perspective only so far. I have the toddler lock working now.

One complication I see, is if a user has custom configured the toddler lock could be on, but Home Assistant won't know about it. I think we would have to do some complicated stuff and if set to custom and current time is in the range of the start/end time then its on. Might not be worth it, as anyone using this would probably use Home Assistant for the schedule? 

Also added a small fix here, I noticed that the color ID can be 0 when the light is off sometimes... not sure why.