### PR TITLE
feat: Handle clock flags and brightness at library level

### DIFF
--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -146,9 +146,13 @@ class RestIot(ShadowClientSubscriberMixin):
         mode = "always" if on else "never"
         self._update({"toddlerLock": {"turnOnMode": mode}})
 
-    def set_clock(self, flags: int, brightness: int = 0):
-        _LOGGER.debug(f"Setting clock on: {flags} and {brightness}")
-        self._update({"clock": {"flags": flags, "i": convert_from_percentage(brightness)}})
+    def set_clock(self, brightness: int = 0):
+        _LOGGER.debug(f"Setting clock on: {brightness}")
+        self._update({"clock": {"flags": 32768, "i": convert_from_percentage(brightness)}})
+
+    def turn_clock_off(self):
+        _LOGGER.debug(f"Turn off clock")
+        self._update({"clock": {"flags": 0, "i": 655}})
 
     # favorite_name_id is expected to be a string of name-id since name alone isn't unique
     def set_favorite(self, favorite_name_id: str):


### PR DESCRIPTION
Changing the API to handle the clock on/off and brightness at the library level.