### PR TITLE
fix: Light not turning off when prompted.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = pathlib.Path(__file__).parent.resolve()
 # Get the long description from the README file
 LONG_DESCRIPTION = (here / "README.md").read_text(encoding="utf-8")
 
-VERSION = "1.19.0"
+VERSION = "1.20.0"
 
 # Setting up
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = pathlib.Path(__file__).parent.resolve()
 # Get the long description from the README file
 LONG_DESCRIPTION = (here / "README.md").read_text(encoding="utf-8")
 
-VERSION = "1.20.0"
+VERSION = "1.19.0"
 
 # Setting up
 setup(

--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -182,7 +182,8 @@ class RestIot(ShadowClientSubscriberMixin):
                     }
                 }
             )
-        self._update(
+        if self.current_playing == "remote":
+            self._update(
                 {
                     "current": {
                         "playing": "none",

--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -167,6 +167,21 @@ class RestIot(ShadowClientSubscriberMixin):
     def turn_light_off(self):
         _LOGGER.debug(f"Turning light off")
         # 9999 = custom color 9998 = turn off
+        # if favorite is playing then light can be turned off without turning off sound
+        if self.current_playing == "routine":
+            self._update(
+                {
+                    "current": {
+                        "color": {
+                            "id": 9998,
+                            "r": 0,
+                            "g": 0,
+                            "b": 0,
+                            "w": 0,
+                        }
+                    }
+                }
+            )
         self._update(
                 {
                     "current": {
@@ -180,8 +195,7 @@ class RestIot(ShadowClientSubscriberMixin):
                         }
                     }
                 }
-        )
-
+            )
     def set_color(
         self,
         red: int,

--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -168,13 +168,18 @@ class RestIot(ShadowClientSubscriberMixin):
         _LOGGER.debug(f"Turning light off")
         # 9999 = custom color 9998 = turn off
         self._update(
-            {
-                "current": {
-                    "color": {
-                        "id": 9998
+                {
+                    "current": {
+                        "playing": "none",
+                        "color": {
+                            "id": 9998,
+                            "r": 0,
+                            "g": 0,
+                            "b": 0,
+                            "w": 0,
+                        }
                     }
                 }
-            }
         )
 
     def set_color(

--- a/src/hatch_rest_api/riot.py
+++ b/src/hatch_rest_api/riot.py
@@ -146,9 +146,13 @@ class RestIot(ShadowClientSubscriberMixin):
         mode = "always" if on else "never"
         self._update({"toddlerLock": {"turnOnMode": mode}})
 
-    def set_clock(self, flags: int, brightness: int = 0):
-        _LOGGER.debug(f"Setting clock on: {flags} and {brightness}")
-        self._update({"clock": {"flags": flags, "i": convert_from_percentage(brightness)}})
+    def set_clock(self, brightness: int = 0):
+        _LOGGER.debug(f"Setting clock on: {brightness}")
+        self._update({"clock": {"flags": 32768, "i": convert_from_percentage(brightness)}})
+
+    def turn_clock_off(self):
+        _LOGGER.debug(f"Turn off clock")
+        self._update({"clock": {"flags": 0, "i": 655}})
 
     # favorite_name_id is expected to be a string of name-id since name alone isn't unique
     def set_favorite(self, favorite_name_id: str):


### PR DESCRIPTION
@w1ll1am23 for some reason the id: 9998 was not turning off the light when prompted. Below is my log file of when my light was still on with an id of 9998.

`current': {'color': {'i': 26214, 'id': 9998, 'r': 0, 'g': 0, 'b': 0, 'w': 65535, 'duration': 0, 'until': 'indefinite'},`

My fix for this is to change "current: playing" from "remote" to "none" and set RGBW to 0 as is done when turning off the Hatch from the iOS app. With this change my light is now functioning as intended but I would like your guys input.