### PR TITLE
fix: Order favorites by displayOrder

### DIFF
--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -111,7 +111,7 @@ class Hatch:
         )
         response_json = await response.json()
         favorites = response_json["payload"]
-        favorites.sort(key=lambda x: x["displayOrder"])
+        favorites.sort(key=lambda x: x.get("displayOrder", float('inf')))
         return favorites
 
     async def content(self, auth_token: str, product: str, content: list):

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -110,7 +110,9 @@ class Hatch:
             )
         )
         response_json = await response.json()
-        return response_json["payload"]
+        favorites = response_json["payload"]
+        favorites.sort(key=lambda x: x["displayOrder"])
+        return favorites
 
     async def content(self, auth_token: str, product: str, content: list):
         # content options are ["sound", "color", "windDown"]


### PR DESCRIPTION
When turning on my Rest 2nd Gen (using ha_hatch), a random favorite would start playing. It seems like the ha_hatch code is picking the first favorite in the list returned by the api. However, this list doesn't seem to be in any particular order and can change. 

This PR sorts the favorites list based on the displayOrder field so the favorites list is always ordered in a sensible way. This also makes sure ha_hatch picks the first favorite when turning on the media player. 