### PR TITLE
feat: Added support to query for Restore routines, and set as favorites

### DIFF
--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -114,6 +114,19 @@ class Hatch:
         favorites.sort(key=lambda x: x.get("displayOrder", float('inf')))
         return favorites
 
+    async def routines(self, auth_token: str, mac: str):
+        url = API_URL + "service/app/routine/v2/fetch"
+        params = {"macAddress": mac, "types": "routine"}
+        response: ClientResponse = (
+            await self._get_request_with_logging_and_errors_raised(
+                url=url, auth_token=auth_token, params=params
+            )
+        )
+        response_json = await response.json()
+        routines = response_json["payload"]
+        routines.sort(key=lambda x: x.get("displayOrder", float('inf')))
+        return routines
+
     async def content(self, auth_token: str, product: str, content: list):
         # content options are ["sound", "color", "windDown"]
         url = API_URL + "service/app/content/v1/fetchByProduct"

--- a/src/hatch_rest_api/restoreiot.py
+++ b/src/hatch_rest_api/restoreiot.py
@@ -130,6 +130,15 @@ class RestoreIot(ShadowClientSubscriberMixin):
         _LOGGER.debug(f"Setting volume: {percentage}")
         self._update({"current": {"sound": {"v": convert_from_percentage(percentage)}}})
 
+    def favorite_names(self, active_only: bool = True):
+        names = []
+        for favorite in self.favorites:
+            if active_only and favorite["active"]:
+                names.append(f"{favorite['name']}-{favorite['id']}")
+            else:
+                names.append(f"{favorite['name']}-{favorite['id']}")
+        return names
+
     def set_clock(self, brightness: int = 0):
         _LOGGER.debug(f"Setting clock on: {brightness}")
         self._update(
@@ -139,6 +148,12 @@ class RestoreIot(ShadowClientSubscriberMixin):
     def turn_clock_off(self):
         _LOGGER.debug("Turn off clock")
         self._update({"clock": {"flags": self.flags ^ RIOT_FLAGS_CLOCK_ON, "i": 655}})
+
+    # favorite_name_id is expected to be a string of name-id since name alone isn't unique
+    def set_favorite(self, favorite_name_id: str):
+        _LOGGER.debug(f"Setting favorite: {favorite_name_id}")
+        fav_id = int(favorite_name_id.split("-")[1])
+        self._update({"current": {"srId": fav_id, "step": 1, "playing": "routine"}})
 
     def turn_off(self):
         _LOGGER.debug("Turning off sound")

--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -32,6 +32,7 @@ async def get_rest_devices(
     iot_devices = await api.iot_devices(auth_token=token)
     aws_token = await api.token(auth_token=token)
     favorites_map = await _get_favorites_for_all_v2_devices(api, token, iot_devices)
+    routines_map = await _get_routines_for_all_v2_devices(api, token, iot_devices)
     # This call will fetch sounds for a v2 device but the official app doesn't appear to use these sounds
     # sounds = await _get_sound_content_for_v2_devices(api, token, iot_devices)
     aws_http: AwsHttp = AwsHttp(api.api_session)
@@ -91,6 +92,7 @@ async def get_rest_devices(
                 thing_name=iot_device["thingName"],
                 mac=iot_device["macAddress"],
                 shadow_client=shadow_client,
+                favorites=routines_map[iot_device["macAddress"]],
             )
         else:
             return RestMini(
@@ -117,6 +119,16 @@ async def _get_favorites_for_all_v2_devices(api, token, iot_devices):
             favorites = await api.favorites(auth_token=token, mac=mac)
             _LOGGER.debug(f"Favorites for {mac}: {favorites}")
             mac_to_fav[mac] = favorites
+    return mac_to_fav
+
+async def _get_routines_for_all_v2_devices(api, token, iot_devices):
+    mac_to_fav = {}
+    for device in iot_devices:
+        if device["product"] in ["restoreIot"]:
+            mac = device["macAddress"]
+            routines = await api.routines(auth_token=token, mac=mac)
+            _LOGGER.debug(f"Routines for {mac}: {routines}")
+            mac_to_fav[mac] = routines
     return mac_to_fav
 
 


### PR DESCRIPTION
Added support for Hatch Restore gen1 to query routines and set as favorites. Leveraging favorites to minimize duplicate code within associated ha_hatch home assistant component.