### PR TITLE
chore: Bumping dependencies to more closely align with HomeAssistant 2024.4.1 release (Python 3.12)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v4.5.0
           with:
-            python-version: "3.10"
+            python-version: "3.12"
             cache: "pip"
 
         - name: "Install requirements"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,10 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install pypa/build
         run: >-

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py310"
+target-version = "py312"
 
 exclude = [
     "stub.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = [
-    "setuptools>=61.0",
+    "setuptools>=68.0.0",
     "wheel",
-    "aiohttp>=3.8.1",
-    "awsiotsdk>=1.21.0"
+    "aiohttp>=3.9.3",
+    "awsiotsdk>=1.21.1"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -15,7 +15,7 @@ authors = [
 ]
 description = "Hatch Rest mini Api Wrapper"
 readme = "README.md"
-requires-python = ">=3.10, <4"
+requires-python = ">=3.12.0, <4"
 dependencies = [
     "aiohttp>=3.8.1",
     "awsiotsdk>=1.16.0"
@@ -25,7 +25,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: MacOS :: MacOS X",
 ]
 keywords = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-setuptools>=42
+setuptools>=68.0.0
 wheel
-colorlog==6.7.0
-pip>=8.0.3,<23.1
-ruff>=0.0.291
-aiohttp>=3.8.1
-awsiotsdk>=1.16.0
+colorlog==6.8.2
+pip>=24
+ruff>=0.3.5
+aiohttp>=3.9.3
+awsiotsdk>=1.21.1


### PR DESCRIPTION
# Summary

Bumping dependencies to more closely align with HomeAssistant 2024.4.1 release (Python 3.12)

Bumps dependencies to latest versions, and overcomes https://github.com/pypa/pip/issues/11501 which I encountered when trying to re-create the venv with Python 3.12 (what HA is running on).