### PR TITLE
feat: Enhance GraphQL and API error handling with rate limiting support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch_rest_api"
-version = "1.27.0"
+version = "1.27.1"
 authors = [
   { name="Brendan Dahl", email="dahl.brendan@gmail.com" },
 ]

--- a/src/hatch_rest_api/contentful.py
+++ b/src/hatch_rest_api/contentful.py
@@ -1,11 +1,16 @@
+import asyncio
 import logging
 
-from aiohttp import ClientSession, ClientResponse, ClientError
+from aiohttp import ClientError, ClientResponse, ClientSession
+
+from .errors import RateError
 
 _LOGGER = logging.getLogger(__name__)
 
 # https://graphql.contentful.com/content/v1/spaces/hlsdh3zwyrtx/explore?access_token=w81AL3BhokPlPGus5Pbs2UjK9hOEH-WYoJ4OOpOQpUI
-API_URL: str = "https://graphql.contentful.com/content/v1/spaces/hlsdh3zwyrtx/environments/master"
+API_URL: str = (
+    "https://graphql.contentful.com/content/v1/spaces/hlsdh3zwyrtx/environments/master"
+)
 AUTH_TOKEN: str = "w81AL3BhokPlPGus5Pbs2UjK9hOEH-WYoJ4OOpOQpUI"
 
 
@@ -16,22 +21,59 @@ class Contentful:
     async def cleanup_client_session(self):
         await self.api_session.close()
 
-    async def graphql_query(self, query, **variables):
-        response: ClientResponse = (
-            await self.api_session.post(
-                url=API_URL,
-                json={
-                    "query": query,
-                    "variables": variables
-                },
-                headers={
-                    "Authorization": f"Bearer {AUTH_TOKEN}",
-                }
-            )
-        )
-        response.raise_for_status()
-        response_json = await response.json()
-        if response_json.get("errors"):
-            _LOGGER.error(f"GraphQL query error: {response_json['errors']}")
-            raise ClientError(f"GraphQL query error: {response_json['errors']}")
-        return response_json.get("data")
+    async def graphql_query(self, query, auth_token=None, max_retries=3, **variables):
+        retry_count = 0
+        while True:
+            try:
+                headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
+                if auth_token:
+                    headers["X-HatchBaby-Auth"] = auth_token
+
+                response: ClientResponse = await self.api_session.post(
+                    url=API_URL,
+                    json={"query": query, "variables": variables},
+                    headers=headers,
+                )
+                if response.status == 429:
+                    _LOGGER.warning("Rate limited (429) for GraphQL query")
+                    raise RateError(
+                        "GraphQL API rate limit exceeded. Please wait before retrying."
+                    )
+
+                response.raise_for_status()
+
+                try:
+                    response_json = await response.json()
+                except Exception:
+                    try:
+                        response_text = await response.text()
+                        _LOGGER.error(
+                            f"Failed to parse JSON response. Status: {response.status}, Content: {response_text[:500]}"
+                        )
+                    except Exception:
+                        _LOGGER.error(
+                            f"Failed to parse response. Status: {response.status}"
+                        )
+                    raise ClientError(
+                        f"Invalid response format from GraphQL API (status: {response.status})"
+                    )
+
+                if response_json.get("errors"):
+                    _LOGGER.error(f"GraphQL query error: {response_json['errors']}")
+                    raise ClientError(f"GraphQL query error: {response_json['errors']}")
+
+                return response_json.get("data")
+
+            except RateError:
+                retry_count += 1
+                if retry_count > max_retries:
+                    _LOGGER.error(
+                        f"Maximum retries ({max_retries}) exceeded for GraphQL query"
+                    )
+                    raise
+
+                wait_time = 2**retry_count
+                _LOGGER.warning(
+                    f"Rate limited. Retrying in {wait_time} seconds (attempt {retry_count}/{max_retries})"
+                )
+                await asyncio.sleep(wait_time)


### PR DESCRIPTION
Attempting to solve the following error while setting up the HA add on. Seems to have broken between 1.26.9 and 1.27.0

> Failed setup, will retry: 429, message='Attempt to decode JSON with unexpected mimetype: text/plain; charset=utf-8', url='https://data.hatchbaby.com/service/app/content/v1/fetchByProduct?product=riot&contentTypes=sound'


- In `hatch.py`:

  - Added detection of 429 status codes BEFORE attempting to parse JSON
  - When a 429 is detected, it raises a `RateError` without trying to parse the response
  - Implemented retry logic with exponential backoff for the `content` method
  - This prevents the JSON decoding error from occurring in the first place

- In `contentful.py`:

  - Added similar rate limit detection before JSON parsing
  - Implemented retry logic with exponential backoff

- In `util_bootstrap.py`:

  - Added error handling for rate limiting in the sound content fetching function
  - Implemented graceful degradation by returning empty sound lists if rate limits persist
