### PR TITLE
chore: improve type hints

### DIFF
--- a/src/hatch_rest_api/aws_http.py
+++ b/src/hatch_rest_api/aws_http.py
@@ -3,6 +3,7 @@ import logging
 from aiohttp import ClientSession, ClientResponse
 import json
 
+from .types import AwsIotCredentialsResponse
 from .util_http import request_with_logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -11,22 +12,22 @@ API_URL: str = "https://data.hatchbaby.com/"
 
 
 class AwsHttp:
-    def __init__(self, client_session: ClientSession = None):
+    def __init__(self, client_session: ClientSession | None = None):
         if client_session is None:
             self.api_session = ClientSession(raise_for_status=True)
         else:
             self.api_session = client_session
 
-    async def cleanup_client_session(self):
+    async def cleanup_client_session(self) -> None:
         await self.api_session.close()
 
     @request_with_logging
     async def _post_request_with_logging_and_errors_raised(
-        self, url: str, json_body: dict, headers: dict = None
+        self, url: str, json_body: dict, headers: dict | None = None
     ) -> ClientResponse:
         return await self.api_session.post(url=url, json=json_body, headers=headers)
 
-    async def aws_credentials(self, region: str, identityId: str, aws_token: str):
+    async def aws_credentials(self, region: str, identityId: str, aws_token: str) -> AwsIotCredentialsResponse:
         url = f"https://cognito-identity.{region}.amazonaws.com"
         json_body = {
             "IdentityId": identityId,

--- a/src/hatch_rest_api/callbacks.py
+++ b/src/hatch_rest_api/callbacks.py
@@ -1,18 +1,19 @@
+from collections.abc import Callable
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class CallbacksMixin:
-    def _setup_callbacks(self):
-        self._callbacks = set()
+    def _setup_callbacks(self) -> None:
+        self._callbacks: set[Callable[[], None]] = set()
 
-    def register_callback(self, callback) -> None:
+    def register_callback(self, callback: Callable[[], None]) -> None:
         if not hasattr(self, "_callbacks"):
             self._setup_callbacks()
         self._callbacks.add(callback)
 
-    def remove_callback(self, callback) -> None:
+    def remove_callback(self, callback: Callable[[], None]) -> None:
         if not hasattr(self, "_callbacks"):
             self._setup_callbacks()
         self._callbacks.discard(callback)

--- a/src/hatch_rest_api/const.py
+++ b/src/hatch_rest_api/const.py
@@ -12,7 +12,7 @@ CUSTOM_COLOR_ID = 9999
 NO_SOUND_ID = 19998
 
 
-class RestMiniAudioTrack(Enum):
+class RestMiniAudioTrack(int, Enum):
     NONE = 0
     Heartbeat = 10124
     Water = 10125
@@ -24,7 +24,7 @@ class RestMiniAudioTrack(Enum):
     Birds = 10131
 
 
-class RestPlusAudioTrack(Enum):
+class RestPlusAudioTrack(int, Enum):
     NONE = 0
     Stream = 2
     PinkNoise = 3
@@ -39,7 +39,7 @@ class RestPlusAudioTrack(Enum):
     RockABye = 14
 
 
-class RIoTAudioTrack(Enum):
+class RIoTAudioTrack(int, Enum):
     NONE = NO_SOUND_ID
     BrownNoise = 10200
     WhiteNoise = 10137
@@ -62,7 +62,7 @@ class RIoTAudioTrack(Enum):
     RockABye = 10194
 
     @classmethod
-    def sound_url_map(cls):
+    def sound_url_map(cls) -> dict[int, str]:
         """
         Hard-coded list, as some of these values are not returned by the 'sounds' API. These were found from manually browsing the app and playing each
         song, collecting the necessary values (name, id, url) from the Home Assistant debug logs for the `ha_hatch` custom component integration.

--- a/src/hatch_rest_api/contentful.py
+++ b/src/hatch_rest_api/contentful.py
@@ -4,6 +4,7 @@ import logging
 from aiohttp import ClientError, ClientResponse, ClientSession
 
 from .errors import RateError
+from .types import JsonType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,13 +16,13 @@ AUTH_TOKEN: str = "w81AL3BhokPlPGus5Pbs2UjK9hOEH-WYoJ4OOpOQpUI"
 
 
 class Contentful:
-    def __init__(self, client_session: ClientSession = None):
+    def __init__(self, client_session: ClientSession | None = None):
         self.api_session = client_session or ClientSession()
 
-    async def cleanup_client_session(self):
+    async def cleanup_client_session(self) -> None:
         await self.api_session.close()
 
-    async def graphql_query(self, query, auth_token=None, max_retries=3, **variables):
+    async def graphql_query(self, query: str, auth_token: str | None = None, max_retries: int = 3, **variables: JsonType) -> dict[str, JsonType]:
         retry_count = 0
         while True:
             try:

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -1,19 +1,39 @@
 import asyncio
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 import logging
+from typing import Literal, TypedDict, overload
 
 from aiohttp import ClientError, ClientResponse, ClientSession, __version__
 from aiohttp.hdrs import USER_AGENT
 
 from .errors import AuthError, RateError
+from .types import (
+    IotDeviceInfo,
+    IotTokenResponse,
+    JsonType,
+    LoginResponse,
+    Product,
+    RestIotRoutine,
+    SimpleSoundContent,
+)
 from .util_http import request_with_logging
+
+type ContentType = Literal["sound", "color", "windDown"]
+
+
+class ContentResponse[T: SimpleSoundContent | Mapping[str, JsonType]](TypedDict):
+    contentItems: list[T]
+
 
 _LOGGER = logging.getLogger(__name__)
 
 API_URL: str = "https://data.hatchbaby.com/"
 
 
-def request_with_logging_and_errors(func):
-    async def request_with_logging_wrapper(*args, **kwargs):
+def request_with_logging_and_errors[**P, T: ClientResponse](
+    func: Callable[P, Awaitable[T]],
+) -> Callable[P, Awaitable[T]]:
+    async def request_with_logging_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         response = await func(*args, **kwargs)
 
         if response.status == 429:
@@ -45,20 +65,20 @@ def request_with_logging_and_errors(func):
 
 
 class Hatch:
-    def __init__(self, client_session: ClientSession = None):
+    def __init__(self, client_session: ClientSession | None = None):
         if client_session is None:
             self.api_session = ClientSession(raise_for_status=True)
         else:
             self.api_session = client_session
         _LOGGER.debug(f"api_session_version: {__version__}")
 
-    async def cleanup_client_session(self):
+    async def cleanup_client_session(self) -> None:
         await self.api_session.close()
 
     @request_with_logging_and_errors
     @request_with_logging
     async def _post_request_with_logging_and_errors_raised(
-        self, url: str, json_body: dict, auth_token: str = None
+        self, url: str, json_body: dict, auth_token: str | None = None
     ) -> ClientResponse:
         headers = {USER_AGENT: "hatch_rest_api"}
         if auth_token is not None:
@@ -68,7 +88,7 @@ class Hatch:
     @request_with_logging
     @request_with_logging_and_errors
     async def _get_request_with_logging_and_errors_raised(
-        self, url: str, auth_token: str = None, params: dict = None
+        self, url: str, auth_token: str | None = None, params: dict | None = None
     ) -> ClientResponse:
         headers = {USER_AGENT: "hatch_rest_api"}
         if auth_token is not None:
@@ -86,10 +106,10 @@ class Hatch:
                 url=url, json_body=json_body
             )
         )
-        response_json = await response.json()
+        response_json: LoginResponse = await response.json()
         return response_json["token"]
 
-    async def member(self, auth_token: str):
+    async def member(self, auth_token: str) -> dict[str, JsonType]:
         url = API_URL + "service/app/v2/member"
         response: ClientResponse = (
             await self._get_request_with_logging_and_errors_raised(
@@ -99,7 +119,7 @@ class Hatch:
         response_json = await response.json()
         return response_json["payload"]
 
-    async def iot_devices(self, auth_token: str):
+    async def iot_devices(self, auth_token: str) -> list[IotDeviceInfo]:
         url = API_URL + "service/app/iotDevice/v2/fetch"
         params = {
             "iotProducts": [
@@ -119,7 +139,7 @@ class Hatch:
         response_json = await response.json()
         return response_json["payload"]
 
-    async def token(self, auth_token: str):
+    async def token(self, auth_token: str) -> IotTokenResponse:
         url = API_URL + "service/app/restPlus/token/v1/fetch"
         response: ClientResponse = (
             await self._get_request_with_logging_and_errors_raised(
@@ -129,7 +149,7 @@ class Hatch:
         response_json = await response.json()
         return response_json["payload"]
 
-    async def favorites(self, auth_token: str, mac: str):
+    async def favorites(self, auth_token: str, mac: str) -> list[RestIotRoutine]:
         url = API_URL + "service/app/routine/v2/fetch"
         params = {"macAddress": mac}
         response: ClientResponse = (
@@ -138,11 +158,11 @@ class Hatch:
             )
         )
         response_json = await response.json()
-        favorites = response_json["payload"]
+        favorites: list[RestIotRoutine] = response_json["payload"]
         favorites.sort(key=lambda x: x.get("displayOrder", float("inf")))
         return favorites
 
-    async def routines(self, auth_token: str, mac: str):
+    async def routines(self, auth_token: str, mac: str) -> list[RestIotRoutine]:
         url = API_URL + "service/app/routine/v2/fetch"
         params = {"macAddress": mac, "types": "routine"}
         response: ClientResponse = (
@@ -151,13 +171,33 @@ class Hatch:
             )
         )
         response_json = await response.json()
-        routines = response_json["payload"]
+        routines: list[RestIotRoutine] = response_json["payload"]
         routines.sort(key=lambda x: x.get("displayOrder", float("inf")))
         return routines
 
+    @overload
     async def content(
-        self, auth_token: str, product: str, content: list, max_retries: int = 3
-    ):
+        self,
+        auth_token: str,
+        product: Product,
+        content: Sequence[Literal["sound"]],
+        max_retries: int = 3,
+    ) -> ContentResponse[SimpleSoundContent]: ...
+    @overload
+    async def content(
+        self,
+        auth_token: str,
+        product: Product,
+        content: Sequence[Literal["color", "windDown"]],
+        max_retries: int = 3,
+    ) -> ContentResponse[Mapping[str, JsonType]]: ...
+    async def content(
+        self,
+        auth_token: str,
+        product: Product,
+        content: Sequence[ContentType],
+        max_retries: int = 3,
+    ) -> ContentResponse[Mapping[str, JsonType]] | ContentResponse[SimpleSoundContent]:
         # content options are ["sound", "color", "windDown"]
         url = API_URL + "service/app/content/v1/fetchByProduct"
         params = {"product": product, "contentTypes": content}

--- a/src/hatch_rest_api/rest_mini.py
+++ b/src/hatch_rest_api/rest_mini.py
@@ -1,22 +1,23 @@
 import logging
 
-from .util import convert_to_percentage, safely_get_json_value, convert_from_percentage
-from .shadow_client_subscriber import ShadowClientSubscriberMixin
 from .const import RestMiniAudioTrack
+from .shadow_client_subscriber import ShadowClientSubscriberMixin
+from .types import JsonType
+from .util import convert_from_percentage, convert_to_percentage, safely_get_json_value
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class RestMini(ShadowClientSubscriberMixin):
-    firmware_version: str = None
-    is_online: bool = None
+    firmware_version: str | None = None
+    is_online: bool | None = None
 
-    audio_track: RestMiniAudioTrack = None
-    volume: int = None
+    audio_track: RestMiniAudioTrack | None = None
+    volume: int | None = None
 
     current_playing: str = "none"
 
-    def __repr__(self):
+    def __repr__(self) -> dict[str, JsonType]:
         return {
             "device_name": self.device_name,
             "thing_name": self.thing_name,
@@ -29,10 +30,10 @@ class RestMini(ShadowClientSubscriberMixin):
             "document_version": self.document_version,
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__repr__()}"
 
-    def _update_local_state(self, state):
+    def _update_local_state(self, state: dict[str, JsonType]) -> None:
         _LOGGER.debug(f"update local state: {self.device_name}, {state}")
         if safely_get_json_value(state, "connected") is not None:
             self.is_online = safely_get_json_value(state, "connected")
@@ -54,7 +55,7 @@ class RestMini(ShadowClientSubscriberMixin):
     def is_playing(self) -> bool:
         return self.current_playing != "none"
 
-    def set_volume(self, percentage: int):
+    def set_volume(self, percentage: float) -> None:
         self._update(
             {
                 "current": {
@@ -65,7 +66,7 @@ class RestMini(ShadowClientSubscriberMixin):
             }
         )
 
-    def set_audio_track(self, audio_track: RestMiniAudioTrack):
+    def set_audio_track(self, audio_track: RestMiniAudioTrack) -> None:
         if audio_track == RestMiniAudioTrack.NONE:
             self._update(
                 {

--- a/src/hatch_rest_api/rest_plus.py
+++ b/src/hatch_rest_api/rest_plus.py
@@ -8,29 +8,30 @@ from .util import (
     convert_to_hex,
 )
 from .shadow_client_subscriber import ShadowClientSubscriberMixin
+from .types import JsonType
 from .const import RestPlusAudioTrack
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class RestPlus(ShadowClientSubscriberMixin):
-    firmware_version: str = None
-    audio_track: RestPlusAudioTrack = None
+    firmware_version: str | None = None
+    audio_track: RestPlusAudioTrack | None = None
     volume: int = 0
 
-    is_on: bool = None
-    battery_level: int = None
-    is_online: bool = None
+    is_on: bool | None = None
+    battery_level: int | None = None
+    is_online: bool | None = None
 
-    red: int = None
-    green: int = None
-    blue: int = None
-    brightness: int = None
+    red: int | None = None
+    green: int | None = None
+    blue: int | None = None
+    brightness: int | None = None
 
-    color_random: bool = None
-    color_white: bool = None
+    color_random: bool | None = None
+    color_white: bool | None = None
 
-    def _update_local_state(self, state):
+    def _update_local_state(self, state: dict[str, JsonType]) -> None:
         _LOGGER.debug(f"update local state: {self.device_name}, {state}")
         if safely_get_json_value(state, "deviceInfo.f") is not None:
             self.firmware_version = safely_get_json_value(state, "deviceInfo.f")
@@ -74,10 +75,10 @@ class RestPlus(ShadowClientSubscriberMixin):
         self.publish_updates()
 
     @property
-    def is_playing(self):
+    def is_playing(self) -> bool:
         return self.is_on and self.audio_track != RestPlusAudioTrack.NONE
 
-    def __repr__(self):
+    def __repr__(self) -> dict[str, JsonType]:
         return {
             "device_name": self.device_name,
             "thing_name": self.thing_name,
@@ -96,10 +97,10 @@ class RestPlus(ShadowClientSubscriberMixin):
             "document_version": self.document_version,
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.__repr__()}"
 
-    def set_volume(self, percentage: int):
+    def set_volume(self, percentage: float) -> None:
         self._update(
             {
                 "a": {
@@ -108,7 +109,7 @@ class RestPlus(ShadowClientSubscriberMixin):
             }
         )
 
-    def set_audio_track(self, audio_track: RestPlusAudioTrack):
+    def set_audio_track(self, audio_track: RestPlusAudioTrack) -> None:
         self._update(
             {
                 "a": {
@@ -117,10 +118,10 @@ class RestPlus(ShadowClientSubscriberMixin):
             }
         )
 
-    def set_on(self, on: bool):
+    def set_on(self, on: bool) -> None:
         self._update({"isPowered": on})
 
-    def set_color(self, red: int, green: int, blue: int, brightness: int, random: bool = False):
+    def set_color(self, red: int, green: int, blue: int, brightness: int, random: bool = False) -> None:
         self._update(
             {
                 "c": {

--- a/src/hatch_rest_api/restore_v5.py
+++ b/src/hatch_rest_api/restore_v5.py
@@ -185,13 +185,14 @@ class RestoreV5(ShadowClientSubscriberMixin):
             self.turn_off()
             return
 
-        if isinstance(sound_or_id_or_title, int):
-            sound = self.sounds_by_id.get(sound_or_id_or_title)
-        elif isinstance(sound_or_id_or_title, str):
-            sound = self.sounds_by_name.get(sound_or_id_or_title)
-        else:
-            # Assume it's a SoundContent or SimpleSoundContent object
-            sound = sound_or_id_or_title
+        match sound_or_id_or_title:
+            case int():
+                sound = self.sounds_by_id.get(sound_or_id_or_title)
+            case str():
+                sound = self.sounds_by_name.get(sound_or_id_or_title)
+            case dict():
+                # Assume it's a SoundContent or SimpleSoundContent object
+                sound = sound_or_id_or_title
 
         if (
             not sound

--- a/src/hatch_rest_api/shadow_client_subscriber.py
+++ b/src/hatch_rest_api/shadow_client_subscriber.py
@@ -1,3 +1,4 @@
+import abc
 import logging
 
 from awscrt import mqtt
@@ -16,7 +17,7 @@ from .types import JsonType, SimpleSoundContent, SoundContent
 _LOGGER = logging.getLogger(__name__)
 
 
-class ShadowClientSubscriberMixin(CallbacksMixin):
+class ShadowClientSubscriberMixin(CallbacksMixin, abc.ABC):
     document_version: int = -1
 
     def __init__(
@@ -78,6 +79,9 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
             f"unsubscribe_topic_to_update_shadow_accepted: {unsubscribe_topic_to_get_shadow_accepted}"
         )
         self.refresh()
+
+    @abc.abstractmethod
+    def _update_local_state(self, state: dict[str, JsonType]) -> None: ...
 
     def _on_update_shadow_accepted(self, response: UpdateShadowResponse) -> None:
         _LOGGER.debug(f"update {self.device_name}, RESPONSE: {response}")

--- a/src/hatch_rest_api/shadow_client_subscriber.py
+++ b/src/hatch_rest_api/shadow_client_subscriber.py
@@ -10,9 +10,8 @@ from awsiot.iotshadow import (
     ShadowState,
 )
 
-from .types import SoundContent, SimpleSoundContent
-
 from .callbacks import CallbacksMixin
+from .types import JsonType, SimpleSoundContent, SoundContent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,11 +38,13 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
         self.shadow_client = shadow_client
         self.favorites = favorites
         self.sounds = sounds
-        self.sounds_by_id = {s['id']: s for s in sounds if s.get('id')}
-        self.sounds_by_name = {s['title']: s for s in sounds if s.get('title')}
+        self.sounds_by_id: dict[int, SoundContent | SimpleSoundContent] = {s["id"]: s for s in sounds if s.get("id")}
+        self.sounds_by_name: dict[str, SoundContent | SimpleSoundContent] = {
+            s["title"]: s for s in sounds if s.get("title")
+        }
         _LOGGER.debug(f"creating {self.__class__.__name__}: {device_name}")
 
-        def update_shadow_accepted(response: UpdateShadowResponse):
+        def update_shadow_accepted(response: UpdateShadowResponse) -> None:
             self._on_update_shadow_accepted(response)
 
         (
@@ -61,7 +62,7 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
             f"unsubscribe_topic_to_update_shadow_accepted: {unsubscribe_topic_to_update_shadow_accepted}"
         )
 
-        def on_get_shadow_accepted(response: GetShadowResponse):
+        def on_get_shadow_accepted(response: GetShadowResponse) -> None:
             self._on_get_shadow_accepted(response)
 
         (
@@ -78,7 +79,7 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
         )
         self.refresh()
 
-    def _on_update_shadow_accepted(self, response: UpdateShadowResponse):
+    def _on_update_shadow_accepted(self, response: UpdateShadowResponse) -> None:
         _LOGGER.debug(f"update {self.device_name}, RESPONSE: {response}")
         if response.version < self.document_version:
             _LOGGER.debug(f'ignoring update {self.device_name}, response version: {response.version} < document version: {self.document_version}')
@@ -89,7 +90,7 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
                 self.document_version = response.version
                 self._update_local_state(response.state.reported)
 
-    def _on_get_shadow_accepted(self, response: GetShadowResponse):
+    def _on_get_shadow_accepted(self, response: GetShadowResponse) -> None:
         _LOGGER.debug(f"get {self.device_name}, RESPONSE: {response}")
         if response.version < self.document_version:
             return
@@ -101,7 +102,7 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
                 self.document_version = response.version
                 self._update_local_state(response.state.reported)
 
-    def _update(self, desired_state):
+    def _update(self, desired_state: dict[str, JsonType]) -> None:
         _LOGGER.debug(f"updating: {desired_state}")
         request: UpdateShadowRequest = UpdateShadowRequest(
             thing_name=self.thing_name,
@@ -113,7 +114,7 @@ class ShadowClientSubscriberMixin(CallbacksMixin):
             request, mqtt.QoS.AT_LEAST_ONCE
         ).result()
 
-    def refresh(self):
+    def refresh(self) -> None:
         _LOGGER.debug("Requesting current shadow state...")
         result = self.shadow_client.publish_get_shadow(
             request=iotshadow.GetShadowRequest(

--- a/src/hatch_rest_api/stub.py
+++ b/src/hatch_rest_api/stub.py
@@ -19,7 +19,7 @@ ch.setFormatter(formatter)
 logger.addHandler(ch)
 
 
-async def testing():
+async def testing() -> None:
     loop = asyncio.get_running_loop()
     email = input("Email: ")
     password = getpass()
@@ -32,7 +32,7 @@ async def testing():
 
         for iot_device in iot_devices:
             if "reading" in iot_device.device_name:
-                def output():
+                def output() -> None:
                     print(f"******-{iot_device}")
 
                 iot_device.register_callback(output)

--- a/src/hatch_rest_api/types.py
+++ b/src/hatch_rest_api/types.py
@@ -1,5 +1,20 @@
-from typing import TypedDict, Any
+from typing import Any, Literal, TypedDict
 
+type JsonType = None | int | str | bool | list[JsonType] | dict[str, JsonType]
+
+type Product = Literal[
+    "rest",
+    "riot",
+    "riotPlus",
+    "restPlus",
+    "restMini",
+    "restore",
+    "restoreIot",
+    "restoreV5",
+    "alexa",
+    "grow",
+    "answeredReader",
+]
 
 class SimpleSoundContent(TypedDict):
     """
@@ -30,15 +45,15 @@ class SoundContent(TypedDict):
     tier: str
     extent: str
     alarmOnly: bool
-    author: "Any | None"
-    narrator: "Any | None"
-    duration: "Any | None"
+    author: Any | None
+    narrator: Any | None
+    duration: Any | None
     imageUrl: str
-    mp3Url: "str | None"
-    wavUrl: "str | None"
+    mp3Url: str | None
+    wavUrl: str | None
     color: Any
-    series: "list[Any]"
-    products: "list[str]"
+    series: list[Any]
+    products: list[str]
     libraryVersion: int
     libraryVersionString: str
     url: str
@@ -46,18 +61,105 @@ class SoundContent(TypedDict):
     hatchId: int
     contentSource: str
     seriesSize: int
-    tagIds: "list"
-    altTagIds: "list"
-    mixIds: "list"
-    red: "Any | None"
-    green: "Any | None"
-    blue: "Any | None"
-    white: "Any | None"
+    tagIds: list
+    altTagIds: list
+    mixIds: list
+    red: Any | None
+    green: Any | None
+    blue: Any | None
+    white: Any | None
     sixCharacterColor: str
     rotateSeries: bool
-    contentfulId: "Any | None"
+    contentfulId: Any | None
     rotationType: str
     legacy: bool
     contentId: int
     contentful: bool
     personalized: bool
+
+type Gender = Literal['MALE', 'FEMALE']
+
+class AwsIotCredentials(TypedDict):
+    AccessKeyId: str
+    Expiration: int
+    SecretKey: str
+    SessionToken: str
+
+class AwsIotCredentialsResponse(TypedDict):
+  Credentials: AwsIotCredentials
+  IdentityId: str
+
+class Baby(TypedDict):
+    id: int
+    createDate: str
+    updateDate: str
+    name: str
+    birthDate: str | None
+    dueDate: str | None
+    birthWeight: int | None
+    birthLength: int | None
+    gender: Gender
+    age: str
+    stage: int
+    lessThanTwoWeeksOld: bool
+
+class Member(TypedDict):
+    id: int
+    createDate: str
+    updateDate: str
+    active: bool
+    email: str
+    babies: list[Baby]
+    defaultUnitOfMeasure: Literal["imperial"] | str
+    appType: Literal["iOS"] | str
+    firstName: str
+    lastName: str | None
+    signupSource: Literal["rest"] | str
+    timezone: str
+    timeZoneAdjust: int
+    stage: int
+
+class LoginResponse(TypedDict):
+    payload: Member
+    sync: int
+    token: str
+
+class IotTokenResponse(TypedDict):
+    endpoint: str
+    identityId: str
+    region: str
+    cognitoPoolId: str
+    token: str
+
+class IotDeviceInfo(TypedDict):
+    id: int
+    createDate: str
+    updateDate: str
+    macAddress: str
+    owner: bool
+    name: str
+    hardwareVersion: str
+    product: Product
+    thingName: str
+    email: str
+    memberId: int
+
+type RestChargingStatus = Literal[0, 3, 5]
+
+class RestIotRoutine(TypedDict):
+    id: int
+    macAddress: str
+    name: str
+    type: Literal["favorite", "sleep", "wake", "flex"]
+    active: bool
+    enabled: bool
+    displayOrder: int
+    sleepScene: bool
+    followBySleepScene: bool
+    button0: bool # true if this routine is available on touch ring
+    startTime: None | str
+    endTime: None | str
+    daysOfWeek: Any | None
+    steps: list[Any]
+
+type IotSoundUntil = Literal["indefinite", "duration"] | str

--- a/src/hatch_rest_api/util.py
+++ b/src/hatch_rest_api/util.py
@@ -1,11 +1,14 @@
 import logging
+from collections.abc import Callable
+from typing import Any, overload
 
 from .const import SENSITIVE_FIELD_NAMES, MAX_IOT_VALUE
+from .types import JsonType
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def clean_dictionary_for_logging(dictionary: dict[str, any]) -> dict[str, any]:
+def clean_dictionary_for_logging(dictionary: dict[str, Any]) -> dict[str, Any]:
     mutable_dictionary = dictionary.copy()
     for key in dictionary:
         if key.lower() in SENSITIVE_FIELD_NAMES:
@@ -26,24 +29,29 @@ def clean_dictionary_for_logging(dictionary: dict[str, any]) -> dict[str, any]:
     return mutable_dictionary
 
 
-def convert_from_percentage(percentage: int):
+def convert_from_percentage(percentage: float) -> int:
     return int(round(percentage / 100.0 * MAX_IOT_VALUE)) & 0xFFFF
 
 
-def convert_to_percentage(value: int):
+def convert_to_percentage(value: int) -> int:
     return round((value & 0xFFFF) / (1.0 * MAX_IOT_VALUE) * 100)
 
 
-def convert_from_hex(percentage: int):
+def convert_from_hex(percentage: int) -> int:
     return int(round(percentage / 255.0 * MAX_IOT_VALUE)) & 0xFFFF
 
 
-def convert_to_hex(value: int):
+def convert_to_hex(value: int) -> int:
     return round((value & 0xFFFF) / (1.0 * MAX_IOT_VALUE) * 255)
 
 
-def safely_get_json_value(json, key, callable_to_cast=None):
-    value = json
+@overload
+def safely_get_json_value[T](json: dict[str, JsonType], key: str, callable_to_cast: Callable[..., T]) -> T | None: ...
+@overload
+def safely_get_json_value(json: dict[str, JsonType], key: str, callable_to_cast: None = None) -> JsonType: ...
+
+def safely_get_json_value[T](json: dict[str, JsonType], key: str, callable_to_cast: Callable[..., T] | None = None) -> T | JsonType | None:
+    value: JsonType = json
     for x in key.split("."):
         if value is not None:
             try:
@@ -54,5 +62,5 @@ def safely_get_json_value(json, key, callable_to_cast=None):
                 except (TypeError, KeyError, ValueError):
                     value = None
     if callable_to_cast is not None and value is not None:
-        value = callable_to_cast(value)
+        return callable_to_cast(value)
     return value

--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from functools import partial
 from re import IGNORECASE, sub
-from typing import Protocol
+from typing import Protocol, TypedDict, cast
 from uuid import uuid4
 
 from aiohttp import ClientSession
@@ -120,47 +120,51 @@ async def get_rest_devices(
         else:
             _LOGGER.debug(f"Iot device {iot_device} has no routines")
             routines = []
-        if iot_device["product"] == "restPlus":
-            return RestPlus(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-            )
-        elif iot_device["product"] in ["riot", "riotPlus"]:
-            return RestIot(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=favorites,
-                sounds=sounds_map[mac_address],
-            )
-        elif iot_device["product"] == "restoreIot":
-            return RestoreIot(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=routines + favorites,
-                sounds=sounds_map[mac_address],
-            )
-        elif iot_device["product"] == "restoreV5":
-            return RestoreV5(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=routines + favorites,
-                sounds=sounds_map[mac_address],
-            )
-        else:
-            return RestMini(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-            )
+
+        match iot_device["product"]:
+            case "restPlus":
+                return RestPlus(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                )
+            case "riot" | "riotPlus":
+                return RestIot(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=favorites,
+                    sounds=sounds_map[mac_address],
+                )
+            case "restoreIot":
+                return RestoreIot(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=routines + favorites,
+                    sounds=sounds_map[mac_address],
+                )
+            case "restoreV5":
+                return RestoreV5(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=routines + favorites,
+                    sounds=sounds_map[mac_address],
+                )
+            case "restMini":
+                return RestMini(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                )
+            case _:
+                raise BaseError(f"Unsupported device type: {iot_device['product']}")
 
     rest_devices = map(create_rest_devices, iot_devices)
     return (
@@ -218,7 +222,7 @@ async def _get_sound_content_for_all_v2_devices(
                 sounds = []
         elif device["product"] == "restoreV5":
             try:
-                content = await contentful.graphql_query(
+                gql_content = await contentful.graphql_query(
                     auth_token=token,
                     query="""
                         query GetSounds($product: String!) {
@@ -253,9 +257,28 @@ async def _get_sound_content_for_all_v2_devices(
                     """,
                     product=device["product"],
                 )
+
+                class GqlSoundFile(TypedDict):
+                    url: str
+
+                class GqlSoundContent(TypedDict):
+                    id: int
+                    title: str
+                    wavFile: GqlSoundFile
+
+                class GqlSoundCollection(TypedDict):
+                    total: int
+                    limit: int
+                    items: list[GqlSoundContent]
+
+                class GqlSoundCollectionResponse(TypedDict):
+                    soundCollection: GqlSoundCollection
+
                 sounds = [
-                    {**s, "wavUrl": s["wavFile"]["url"]}
-                    for s in content["soundCollection"]["items"]
+                    {"id": s["id"], "title": s["title"], "wavUrl": s["wavFile"]["url"]}
+                    for s in cast(GqlSoundCollectionResponse, gql_content)[
+                        "soundCollection"
+                    ]["items"]
                     if s["id"] != NO_SOUND_ID
                 ]
             except RateError as e:

--- a/src/hatch_rest_api/util_http.py
+++ b/src/hatch_rest_api/util_http.py
@@ -1,18 +1,23 @@
+from collections.abc import Awaitable, Callable
 import logging
+from typing import cast
 
+from aiohttp import ClientResponse
+
+from .types import JsonType
 from .util import clean_dictionary_for_logging
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def request_with_logging(func):
-    async def request_with_logging_wrapper(*args, **kwargs):
+def request_with_logging[**P, T: ClientResponse](func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    async def request_with_logging_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         url = kwargs["url"]
         request_message = f"sending {url} request"
         headers = kwargs.get("headers")
         if headers is not None:
             request_message = request_message + f"headers: {headers}"
-        json_body = kwargs.get("json_body")
+        json_body = cast(dict[str, JsonType], kwargs.get("json_body"))
         if json_body is not None:
             request_message = (
                 request_message


### PR DESCRIPTION
Trying to debug some issues with my setup. Started by refining the type hints so that I can be a bit more confident about any changes.

* The first commit in the PR should be exclusively type hint changes, there should be no runtime effect at all[^1]
* The second commit is much smaller and has some changes that affect runtime behavior (although I matched the existing behavior as close as possible)

There are a number of mypy errors remaining[^2] that need actual fixes in the code to resolve:
* [ ] code that can't be feasibly annotated, such as `safely_get_json_value`
* [ ] code that calls into un-typed packages (i.e. `awsiot`)
  * we could stub this out ourself but I'm not sure how beneficial that would be
* [ ] `request_with_logging` [calls `clean_dictionary_for_logging` on a `MultiDict`](https://github.com/dahlb/hatch_rest_api/blob/28b91cc5467a8b5856b8e2036f7f1919ccdcc4e1/src/hatch_rest_api/util_http.py#L29)
* [ ] [`RestIot.is_clock_on`](https://github.com/dahlb/hatch_rest_api/blob/28b91cc5467a8b5856b8e2036f7f1919ccdcc4e1/src/hatch_rest_api/rest_iot.py#L153-L155) returning an `int` instead of `bool`
  * technically this works because of thruthiness but narrowing the return type can't hurt
* [ ] many classes' [`__repr__()` function return a dict](https://github.com/dahlb/hatch_rest_api/blob/28b91cc5467a8b5856b8e2036f7f1919ccdcc4e1/src/hatch_rest_api/restore_v5.py#L90-L114), which is not allowed

[^1]: other than the `from ... import ...` calls. But the package doesn't have any import-time side-effects, AFAICT
[^2]: 43, with my configuration that attempts to match [the upstream homeassistant mypy config](safely_get_json_value)