### PR TITLE
fix: call init_logging once at module level to survive credential refresh

### DIFF
--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -27,6 +27,8 @@ from .types import SimpleSoundContent
 
 _LOGGER = logging.getLogger(__name__)
 
+io.init_logging(io.LogLevel.NoLogs, "stderr")
+
 
 async def get_rest_devices(
     email: str,
@@ -36,10 +38,8 @@ async def get_rest_devices(
     on_connection_resumed=None,
 ):
     loop = asyncio.get_running_loop()
-    if _LOGGER.isEnabledFor(logging.DEBUG):
-        await loop.run_in_executor(
-            None, io.init_logging, io.LogLevel.Debug, "hatch_rest_api-aws_mqtt.log"
-        )
+    aws_log_level = io.LogLevel.Debug if _LOGGER.isEnabledFor(logging.DEBUG) else io.LogLevel.NoLogs
+    await loop.run_in_executor(None, io.set_log_level, aws_log_level)
     api = Hatch(client_session=client_session)
     contentful = Contentful(client_session=client_session)
     token = await api.login(email=email, password=password)


### PR DESCRIPTION
Two changes

1) io.init_logging() can only be called once per process; a second call raises RuntimeError (AWS_ERROR_INVALID_STATE).  Move it to module level and use set_log_level() in get_rest_devices() to dynamically sync the AWS log level with the current Python logger.

2) Log output is directed to stderr instead of a file, keeping it visible in Home Assistant's log stream without writing a separate log file to disk.

Let me know if you need me to do anything

[fixes #48]