### PR TITLE
feat: Restore alarm support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch_rest_api"
-version = "1.33.0"
+version = "1.32.1"
 authors = [
   { name="Brendan Dahl", email="dahl.brendan@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch_rest_api"
-version = "1.32.1"
+version = "1.33.0"
 authors = [
   { name="Brendan Dahl", email="dahl.brendan@gmail.com" },
 ]

--- a/src/hatch_rest_api/__init__.py
+++ b/src/hatch_rest_api/__init__.py
@@ -6,7 +6,9 @@ from .rest_plus import RestPlus
 from .rest_iot import RestIot
 from .rest_baby import RestBaby
 from .restore_iot import RestoreIot
+from .restore_v4 import RestoreV4
 from .restore_v5 import RestoreV5
+from .scheduled_routine import ScheduledRoutineAlarm
 from .util_bootstrap import get_rest_devices
 from .const import (
     RestMiniAudioTrack,
@@ -22,4 +24,4 @@ from .const import (
     TimeForBedTrack,
     TIME_FOR_BED_TRACKS,
 )
-RestDevice = RestMini | RestPlus | RestIot | RestBaby | RestoreIot | RestoreV5
+RestDevice = RestMini | RestPlus | RestIot | RestBaby | RestoreIot | RestoreV4 | RestoreV5

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -1,10 +1,17 @@
 import asyncio
 import logging
+from typing import Any
 
 from aiohttp import ClientError, ClientResponse, ClientSession, __version__
 from aiohttp.hdrs import USER_AGENT
 
 from .errors import AuthError, RateError
+from .scheduled_routine import (
+    ALARM_ROUTINE_TYPE,
+    ScheduledRoutineAlarm,
+    alarm_routines,
+    alarm_update_payload,
+)
 from .util_http import request_with_logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,6 +163,104 @@ class Hatch:
         routines = response_json["payload"]
         routines.sort(key=lambda x: x.get("displayOrder", float("inf")))
         return routines
+
+    async def scheduled_routines(
+        self,
+        auth_token: str,
+        mac: str,
+        types: list[str] | None = None,
+    ) -> list[ScheduledRoutineAlarm]:
+        url = API_URL + "service/app/routine/v3/fetch"
+        params: dict[str, str | list[str]] = {"macAddress": mac}
+        if types is not None:
+            params["types"] = types
+        response: ClientResponse = (
+            await self._get_request_with_logging_and_errors_raised(
+                url=url, auth_token=auth_token, params=params
+            )
+        )
+        response_json = await response.json()
+        routines = response_json["payload"]
+        routines.sort(key=lambda x: x.get("displayOrder", float("inf")))
+        return routines
+
+    async def update_scheduled_routine_alarm_enabled(
+        self,
+        auth_token: str,
+        mac: str,
+        alarm: ScheduledRoutineAlarm,
+        enabled: bool,
+    ) -> list[ScheduledRoutineAlarm]:
+        payload = await self.edit_scheduled_routines(
+            auth_token=auth_token,
+            mutable_scheduled_routines=[alarm_update_payload(alarm, enabled)],
+            routine_type=ALARM_ROUTINE_TYPE,
+        )
+        updated_routines = alarm_routines(payload.get("item") or [])
+
+        if payload.get("confirmDataVersion") and payload.get("dataVersion"):
+            try:
+                confirmed_routines = await self.confirm_data_version(
+                    auth_token=auth_token,
+                    mac=mac,
+                    data_version=payload["dataVersion"],
+                    success=True,
+                    return_all_routines=True,
+                )
+                if confirmed_routines:
+                    updated_routines = alarm_routines(confirmed_routines)
+            except ClientError as error:
+                _LOGGER.warning(
+                    "Could not confirm scheduled routine data version for %s",
+                    mac,
+                    exc_info=error,
+                )
+
+        return updated_routines
+
+    async def edit_scheduled_routines(
+        self,
+        auth_token: str,
+        mutable_scheduled_routines: list[dict[str, Any]],
+        routine_type: str,
+    ) -> dict:
+        url = API_URL + "service/app/routine/v2/editMultiple"
+        response: ClientResponse = (
+            await self._post_request_with_logging_and_errors_raised(
+                url=url,
+                auth_token=auth_token,
+                json_body={
+                    "mrds": mutable_scheduled_routines,
+                    "type": routine_type,
+                },
+            )
+        )
+        response_json = await response.json()
+        return response_json["payload"]
+
+    async def confirm_data_version(
+        self,
+        auth_token: str,
+        mac: str,
+        data_version: str,
+        success: bool = True,
+        return_all_routines: bool = True,
+    ) -> list[ScheduledRoutineAlarm]:
+        url = API_URL + "service/app/v2/dataVersion"
+        response: ClientResponse = (
+            await self._post_request_with_logging_and_errors_raised(
+                url=url,
+                auth_token=auth_token,
+                json_body={
+                    "dataVersion": data_version,
+                    "macAddress": mac,
+                    "success": success,
+                    "returnAllRoutines": return_all_routines,
+                },
+            )
+        )
+        response_json = await response.json()
+        return response_json["payload"]
 
     async def content(
         self, auth_token: str, product: str, content: list, max_retries: int = 3

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Iterable
 from datetime import time
 from typing import Any
 
@@ -12,6 +13,7 @@ from .scheduled_routine import (
     ScheduledRoutineAlarm,
     alarm_routines,
     alarm_update_payload,
+    alarm_weekdays_update_payload,
     alarm_wake_time_update_payload,
 )
 from .util_http import request_with_logging
@@ -231,6 +233,42 @@ class Hatch:
             auth_token=auth_token,
             mutable_scheduled_routines=[
                 alarm_wake_time_update_payload(alarm, wake_time)
+            ],
+            routine_type=ALARM_ROUTINE_TYPE,
+        )
+        updated_routines = alarm_routines(payload.get("item") or [])
+
+        if payload.get("confirmDataVersion") and payload.get("dataVersion"):
+            try:
+                confirmed_routines = await self.confirm_data_version(
+                    auth_token=auth_token,
+                    mac=mac,
+                    data_version=payload["dataVersion"],
+                    success=True,
+                    return_all_routines=True,
+                )
+                if confirmed_routines:
+                    updated_routines = alarm_routines(confirmed_routines)
+            except ClientError as error:
+                _LOGGER.warning(
+                    "Could not confirm scheduled routine data version for %s",
+                    mac,
+                    exc_info=error,
+                )
+
+        return updated_routines
+
+    async def update_scheduled_routine_alarm_weekdays(
+        self,
+        auth_token: str,
+        mac: str,
+        alarm: ScheduledRoutineAlarm,
+        weekdays: Iterable[str],
+    ) -> list[ScheduledRoutineAlarm]:
+        payload = await self.edit_scheduled_routines(
+            auth_token=auth_token,
+            mutable_scheduled_routines=[
+                alarm_weekdays_update_payload(alarm, weekdays)
             ],
             routine_type=ALARM_ROUTINE_TYPE,
         )

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -257,9 +257,17 @@ class Hatch:
                     updated_routines = alarm_routines(confirmed_routines)
             except ClientError as error:
                 _LOGGER.warning(
-                    "Could not confirm scheduled routine data version for %s",
+                    "Could not confirm scheduled routine data version for %s; "
+                    "refetching authoritative routines",
                     mac,
                     exc_info=error,
+                )
+                updated_routines = alarm_routines(
+                    await self.scheduled_routines(
+                        auth_token=auth_token,
+                        mac=mac,
+                        types=[ALARM_ROUTINE_TYPE],
+                    )
                 )
 
         return updated_routines

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from datetime import time
 from typing import Any
 
 from aiohttp import ClientError, ClientResponse, ClientSession, __version__
@@ -11,6 +12,7 @@ from .scheduled_routine import (
     ScheduledRoutineAlarm,
     alarm_routines,
     alarm_update_payload,
+    alarm_wake_time_update_payload,
 )
 from .util_http import request_with_logging
 
@@ -194,6 +196,42 @@ class Hatch:
         payload = await self.edit_scheduled_routines(
             auth_token=auth_token,
             mutable_scheduled_routines=[alarm_update_payload(alarm, enabled)],
+            routine_type=ALARM_ROUTINE_TYPE,
+        )
+        updated_routines = alarm_routines(payload.get("item") or [])
+
+        if payload.get("confirmDataVersion") and payload.get("dataVersion"):
+            try:
+                confirmed_routines = await self.confirm_data_version(
+                    auth_token=auth_token,
+                    mac=mac,
+                    data_version=payload["dataVersion"],
+                    success=True,
+                    return_all_routines=True,
+                )
+                if confirmed_routines:
+                    updated_routines = alarm_routines(confirmed_routines)
+            except ClientError as error:
+                _LOGGER.warning(
+                    "Could not confirm scheduled routine data version for %s",
+                    mac,
+                    exc_info=error,
+                )
+
+        return updated_routines
+
+    async def update_scheduled_routine_alarm_wake_time(
+        self,
+        auth_token: str,
+        mac: str,
+        alarm: ScheduledRoutineAlarm,
+        wake_time: time,
+    ) -> list[ScheduledRoutineAlarm]:
+        payload = await self.edit_scheduled_routines(
+            auth_token=auth_token,
+            mutable_scheduled_routines=[
+                alarm_wake_time_update_payload(alarm, wake_time)
+            ],
             routine_type=ALARM_ROUTINE_TYPE,
         )
         updated_routines = alarm_routines(payload.get("item") or [])

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -195,32 +195,11 @@ class Hatch:
         alarm: ScheduledRoutineAlarm,
         enabled: bool,
     ) -> list[ScheduledRoutineAlarm]:
-        payload = await self.edit_scheduled_routines(
+        return await self._edit_and_confirm_alarm_routines(
             auth_token=auth_token,
+            mac=mac,
             mutable_scheduled_routines=[alarm_update_payload(alarm, enabled)],
-            routine_type=ALARM_ROUTINE_TYPE,
         )
-        updated_routines = alarm_routines(payload.get("item") or [])
-
-        if payload.get("confirmDataVersion") and payload.get("dataVersion"):
-            try:
-                confirmed_routines = await self.confirm_data_version(
-                    auth_token=auth_token,
-                    mac=mac,
-                    data_version=payload["dataVersion"],
-                    success=True,
-                    return_all_routines=True,
-                )
-                if confirmed_routines:
-                    updated_routines = alarm_routines(confirmed_routines)
-            except ClientError as error:
-                _LOGGER.warning(
-                    "Could not confirm scheduled routine data version for %s",
-                    mac,
-                    exc_info=error,
-                )
-
-        return updated_routines
 
     async def update_scheduled_routine_alarm_wake_time(
         self,
@@ -229,34 +208,13 @@ class Hatch:
         alarm: ScheduledRoutineAlarm,
         wake_time: time,
     ) -> list[ScheduledRoutineAlarm]:
-        payload = await self.edit_scheduled_routines(
+        return await self._edit_and_confirm_alarm_routines(
             auth_token=auth_token,
+            mac=mac,
             mutable_scheduled_routines=[
                 alarm_wake_time_update_payload(alarm, wake_time)
             ],
-            routine_type=ALARM_ROUTINE_TYPE,
         )
-        updated_routines = alarm_routines(payload.get("item") or [])
-
-        if payload.get("confirmDataVersion") and payload.get("dataVersion"):
-            try:
-                confirmed_routines = await self.confirm_data_version(
-                    auth_token=auth_token,
-                    mac=mac,
-                    data_version=payload["dataVersion"],
-                    success=True,
-                    return_all_routines=True,
-                )
-                if confirmed_routines:
-                    updated_routines = alarm_routines(confirmed_routines)
-            except ClientError as error:
-                _LOGGER.warning(
-                    "Could not confirm scheduled routine data version for %s",
-                    mac,
-                    exc_info=error,
-                )
-
-        return updated_routines
 
     async def update_scheduled_routine_alarm_weekdays(
         self,
@@ -265,11 +223,23 @@ class Hatch:
         alarm: ScheduledRoutineAlarm,
         weekdays: Iterable[str],
     ) -> list[ScheduledRoutineAlarm]:
-        payload = await self.edit_scheduled_routines(
+        return await self._edit_and_confirm_alarm_routines(
             auth_token=auth_token,
+            mac=mac,
             mutable_scheduled_routines=[
                 alarm_weekdays_update_payload(alarm, weekdays)
             ],
+        )
+
+    async def _edit_and_confirm_alarm_routines(
+        self,
+        auth_token: str,
+        mac: str,
+        mutable_scheduled_routines: list[dict[str, Any]],
+    ) -> list[ScheduledRoutineAlarm]:
+        payload = await self.edit_scheduled_routines(
+            auth_token=auth_token,
+            mutable_scheduled_routines=mutable_scheduled_routines,
             routine_type=ALARM_ROUTINE_TYPE,
         )
         updated_routines = alarm_routines(payload.get("item") or [])

--- a/src/hatch_rest_api/restore_iot.py
+++ b/src/hatch_rest_api/restore_iot.py
@@ -14,12 +14,13 @@ from .const import (
     NO_COLOR_ID,
     CUSTOM_COLOR_ID,
 )
+from .scheduled_routine import ScheduledRoutineAlarmMixin
 from .shadow_client_subscriber import ShadowClientSubscriberMixin
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class RestoreIot(ShadowClientSubscriberMixin):
+class RestoreIot(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
     audio_track: str = None
     firmware_version: str = None
     volume: int = 0

--- a/src/hatch_rest_api/restore_v5.py
+++ b/src/hatch_rest_api/restore_v5.py
@@ -15,12 +15,13 @@ from .const import (
     NO_COLOR_ID,
     CUSTOM_COLOR_ID,
 )
+from .scheduled_routine import ScheduledRoutineAlarmMixin
 from .shadow_client_subscriber import ShadowClientSubscriberMixin
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class RestoreV5(ShadowClientSubscriberMixin):
+class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
     firmware_version: str = None
     volume: int = 0
 

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -447,18 +447,21 @@ class ScheduledRoutineAlarmMixin:
         if alarm is None:
             raise ValueError(f"Alarm {alarm_id} not found for {self.device_name}")
 
+        # Materialize once so the API call and the fallback payload see the same values
+        # even if the caller passed a single-pass generator.
+        weekdays_list = list(weekdays)
         api, auth_token = self._configured_alarm_api()
         updated_alarms = await api.update_scheduled_routine_alarm_weekdays(
             auth_token=auth_token,
             mac=self.mac,
             alarm=alarm,
-            weekdays=weekdays,
+            weekdays=weekdays_list,
         )
         if updated_alarms:
             self._replace_alarms(updated_alarms)
         else:
             self._replace_alarms(
-                [{**alarm, **alarm_weekdays_update_payload(alarm, weekdays)}]
+                [{**alarm, **alarm_weekdays_update_payload(alarm, weekdays_list)}]
             )
         self.publish_updates()
 

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -5,6 +5,10 @@ if TYPE_CHECKING:
     from .hatch import Hatch
 
 ALARM_ROUTINE_TYPE = "alarm"
+# Android models scheduled-routine alarms this way for Restore, Restore 2, and Restore 3.
+SCHEDULED_ROUTINE_ALARM_PRODUCTS: frozenset[str] = frozenset(
+    {"restoreIot", "restoreV4", "restoreV5"}
+)
 
 
 class ScheduledRoutineAlarm(TypedDict, total=False):

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -405,7 +405,9 @@ class ScheduledRoutineAlarmMixin:
         if updated_alarms:
             self._replace_alarms(updated_alarms)
         else:
-            alarm["enabled"] = enabled
+            self._replace_alarms(
+                [{**alarm, **alarm_update_payload(alarm, enabled)}]
+            )
         self.publish_updates()
 
     async def set_alarm_wake_time(self, alarm_id: int | str, wake_time: time) -> None:

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -1,0 +1,184 @@
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
+
+if TYPE_CHECKING:
+    from .hatch import Hatch
+
+ALARM_ROUTINE_TYPE = "alarm"
+
+
+class ScheduledRoutineAlarm(TypedDict, total=False):
+    id: int
+    name: str
+    active: bool
+    enabled: bool
+    type: str
+    macAddress: str
+    startTime: str | None
+    endTime: str | None
+    daysOfWeek: int | None
+    displayOrder: int | None
+    steps: NotRequired[list[dict[str, Any]]]
+
+
+def alarm_update_payload(
+    alarm: ScheduledRoutineAlarm,
+    enabled: bool,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if "id" not in alarm:
+        raise ValueError("Cannot update alarm without an id")
+
+    start_time = alarm.get("startTime")
+    if enabled and _is_one_time_alarm(alarm):
+        start_time = _next_one_time_start_time(start_time, now=now)
+
+    return {
+        "id": alarm["id"],
+        "name": alarm.get("name"),
+        "active": alarm.get("active"),
+        "enabled": enabled,
+        "displayOrder": alarm.get("displayOrder"),
+        "startTime": start_time,
+        "endTime": alarm.get("endTime"),
+    }
+
+
+def alarm_routines(routines: list[ScheduledRoutineAlarm]) -> list[ScheduledRoutineAlarm]:
+    return [
+        routine
+        for routine in routines
+        if routine.get("type") == ALARM_ROUTINE_TYPE
+    ]
+
+
+def _is_one_time_alarm(alarm: ScheduledRoutineAlarm) -> bool:
+    days_of_week = alarm.get("daysOfWeek")
+    return days_of_week is None or days_of_week == 0
+
+
+def _next_one_time_start_time(
+    start_time: str | None,
+    now: datetime | None = None,
+) -> str | None:
+    if not isinstance(start_time, str):
+        return start_time
+
+    parsed_start_time = _parse_local_datetime(start_time)
+    if parsed_start_time is None:
+        return start_time
+
+    if now is None:
+        now = datetime.now()
+    if parsed_start_time.tzinfo is not None:
+        parsed_start_time = parsed_start_time.replace(tzinfo=None)
+    if now.tzinfo is not None:
+        now = now.replace(tzinfo=None)
+
+    next_start_time = datetime.combine(now.date(), parsed_start_time.time())
+    if next_start_time <= now:
+        next_start_time = next_start_time + timedelta(days=1)
+
+    return _format_like_original(start_time, next_start_time)
+
+
+def _parse_local_datetime(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _format_like_original(original: str, value: datetime) -> str:
+    if "." in original:
+        return value.isoformat()
+    if len(original.split("T", 1)[-1].split(":")) <= 2:
+        return value.isoformat(timespec="minutes")
+    return value.isoformat(timespec="seconds")
+
+
+class ScheduledRoutineAlarmMixin:
+    alarms: list[ScheduledRoutineAlarm]
+    alarms_loaded: bool = False
+    _alarm_api: "Hatch | None" = None
+    _alarm_auth_token: str | None = None
+
+    def configure_alarm_api(
+        self,
+        api: "Hatch",
+        auth_token: str,
+        alarms: list[ScheduledRoutineAlarm] | None = None,
+    ) -> None:
+        self._alarm_api = api
+        self._alarm_auth_token = auth_token
+        self.alarms_loaded = alarms is not None
+        self.alarms = list(alarms or [])
+
+    def alarm_by_id(self, alarm_id: int | str) -> ScheduledRoutineAlarm | None:
+        alarm_id_string = str(alarm_id)
+        return next(
+            (
+                alarm
+                for alarm in getattr(self, "alarms", [])
+                if str(alarm.get("id")) == alarm_id_string
+            ),
+            None,
+        )
+
+    async def refresh_alarms(self) -> list[ScheduledRoutineAlarm]:
+        api, auth_token = self._configured_alarm_api()
+        self.alarms = await api.scheduled_routines(
+            auth_token=auth_token,
+            mac=self.mac,
+            types=[ALARM_ROUTINE_TYPE],
+        )
+        self.alarms_loaded = True
+        self.publish_updates()
+        return self.alarms
+
+    async def set_alarm_enabled(self, alarm_id: int | str, enabled: bool) -> None:
+        alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            await self.refresh_alarms()
+            alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            raise ValueError(f"Alarm {alarm_id} not found for {self.device_name}")
+
+        api, auth_token = self._configured_alarm_api()
+        updated_alarms = await api.update_scheduled_routine_alarm_enabled(
+            auth_token=auth_token,
+            mac=self.mac,
+            alarm=alarm,
+            enabled=enabled,
+        )
+        if updated_alarms:
+            self._replace_alarms(updated_alarms)
+        else:
+            alarm["enabled"] = enabled
+        self.publish_updates()
+
+    def _configured_alarm_api(self) -> tuple["Hatch", str]:
+        if self._alarm_api is None or self._alarm_auth_token is None:
+            raise RuntimeError(f"{self.device_name} alarm API is not configured")
+        return self._alarm_api, self._alarm_auth_token
+
+    def _replace_alarms(self, updated_alarms: list[ScheduledRoutineAlarm]) -> None:
+        if not updated_alarms:
+            return
+
+        by_id = {
+            str(alarm.get("id")): alarm
+            for alarm in updated_alarms
+            if alarm.get("id") is not None
+        }
+        merged = [
+            by_id.get(str(alarm.get("id")), alarm)
+            for alarm in getattr(self, "alarms", [])
+        ]
+        existing_ids = {str(alarm.get("id")) for alarm in merged}
+        merged.extend(
+            alarm
+            for alarm_id, alarm in by_id.items()
+            if alarm_id not in existing_ids
+        )
+        self.alarms = merged

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -350,6 +350,7 @@ def _format_like_original(original: str | None, value: datetime) -> str:
 
 class ScheduledRoutineAlarmMixin:
     alarms: list[ScheduledRoutineAlarm]
+    alarm_capable: bool = False
     alarms_loaded: bool = False
     _alarm_api: "Hatch | None" = None
     _alarm_auth_token: str | None = None
@@ -362,6 +363,7 @@ class ScheduledRoutineAlarmMixin:
     ) -> None:
         self._alarm_api = api
         self._alarm_auth_token = auth_token
+        self.alarm_capable = True
         self.alarms_loaded = alarms is not None
         self.alarms = list(alarms or [])
 

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -11,22 +11,22 @@ SCHEDULED_ROUTINE_ALARM_PRODUCTS: frozenset[str] = frozenset(
     {"restoreIot", "restoreV4", "restoreV5"}
 )
 WEEKDAY_BITS: dict[str, int] = {
-    "sunday": 1,
     "monday": 2,
     "tuesday": 4,
     "wednesday": 8,
     "thursday": 16,
     "friday": 32,
     "saturday": 64,
+    "sunday": 1,
 }
 WEEKDAY_SHORT_NAMES: dict[str, str] = {
-    "sunday": "Sun",
     "monday": "Mon",
     "tuesday": "Tue",
     "wednesday": "Wed",
     "thursday": "Thu",
     "friday": "Fri",
     "saturday": "Sat",
+    "sunday": "Sun",
 }
 WEEKDAYS_MASK = sum(WEEKDAY_BITS.values())
 WEEKDAYS_ONLY_MASK = (

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -1,4 +1,5 @@
 from datetime import datetime, time, timedelta
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 if TYPE_CHECKING:
@@ -9,6 +10,33 @@ ALARM_ROUTINE_TYPE = "alarm"
 SCHEDULED_ROUTINE_ALARM_PRODUCTS: frozenset[str] = frozenset(
     {"restoreIot", "restoreV4", "restoreV5"}
 )
+WEEKDAY_BITS: dict[str, int] = {
+    "sunday": 1,
+    "monday": 2,
+    "tuesday": 4,
+    "wednesday": 8,
+    "thursday": 16,
+    "friday": 32,
+    "saturday": 64,
+}
+WEEKDAY_SHORT_NAMES: dict[str, str] = {
+    "sunday": "Sun",
+    "monday": "Mon",
+    "tuesday": "Tue",
+    "wednesday": "Wed",
+    "thursday": "Thu",
+    "friday": "Fri",
+    "saturday": "Sat",
+}
+WEEKDAYS_MASK = sum(WEEKDAY_BITS.values())
+WEEKDAYS_ONLY_MASK = (
+    WEEKDAY_BITS["monday"]
+    | WEEKDAY_BITS["tuesday"]
+    | WEEKDAY_BITS["wednesday"]
+    | WEEKDAY_BITS["thursday"]
+    | WEEKDAY_BITS["friday"]
+)
+WEEKENDS_MASK = WEEKDAY_BITS["sunday"] | WEEKDAY_BITS["saturday"]
 
 
 class ScheduledRoutineAlarm(TypedDict, total=False):
@@ -94,6 +122,63 @@ def alarm_wake_time_update_payload(
     }
 
 
+def alarm_weekdays_update_payload(
+    alarm: ScheduledRoutineAlarm,
+    weekdays: Iterable[str],
+) -> dict[str, Any]:
+    if "id" not in alarm:
+        raise ValueError("Cannot update alarm without an id")
+
+    return {
+        "id": alarm["id"],
+        "name": alarm.get("name"),
+        "active": alarm.get("active"),
+        "enabled": alarm.get("enabled"),
+        "displayOrder": alarm.get("displayOrder"),
+        "startTime": alarm.get("startTime"),
+        "endTime": alarm.get("endTime"),
+        "daysOfWeek": weekdays_to_days_of_week(weekdays),
+    }
+
+
+def weekdays_to_days_of_week(weekdays: Iterable[str]) -> int:
+    days_of_week = 0
+    if isinstance(weekdays, str):
+        weekdays = [weekdays]
+    for weekday in weekdays:
+        normalized_weekday = str(weekday).strip().lower()
+        try:
+            days_of_week |= WEEKDAY_BITS[normalized_weekday]
+        except KeyError as error:
+            raise ValueError(f"Unsupported alarm weekday: {weekday}") from error
+    return days_of_week
+
+
+def days_of_week_to_weekdays(days_of_week: int | None) -> list[str]:
+    normalized_days_of_week = _normalize_days_of_week(days_of_week)
+    return [
+        weekday
+        for weekday, bit in WEEKDAY_BITS.items()
+        if normalized_days_of_week & bit
+    ]
+
+
+def days_of_week_label(days_of_week: int | None) -> str:
+    normalized_days_of_week = _normalize_days_of_week(days_of_week)
+    if normalized_days_of_week == 0:
+        return "Once"
+    if normalized_days_of_week == WEEKDAYS_ONLY_MASK:
+        return "Weekdays"
+    if normalized_days_of_week == WEEKENDS_MASK:
+        return "Weekends"
+    if normalized_days_of_week == WEEKDAYS_MASK:
+        return "Every day"
+    return ", ".join(
+        WEEKDAY_SHORT_NAMES[weekday]
+        for weekday in days_of_week_to_weekdays(normalized_days_of_week)
+    )
+
+
 def alarm_routines(routines: list[ScheduledRoutineAlarm]) -> list[ScheduledRoutineAlarm]:
     return [
         routine
@@ -105,6 +190,16 @@ def alarm_routines(routines: list[ScheduledRoutineAlarm]) -> list[ScheduledRouti
 def _is_one_time_alarm(alarm: ScheduledRoutineAlarm) -> bool:
     days_of_week = alarm.get("daysOfWeek")
     return days_of_week is None or days_of_week == 0
+
+
+def _normalize_days_of_week(days_of_week: int | None) -> int:
+    if days_of_week is None:
+        return 0
+    if isinstance(days_of_week, bool) or not isinstance(days_of_week, int):
+        raise TypeError(f"Unsupported alarm daysOfWeek value: {days_of_week}")
+    if days_of_week < 0 or days_of_week > WEEKDAYS_MASK:
+        raise ValueError(f"Unsupported alarm daysOfWeek value: {days_of_week}")
+    return days_of_week
 
 
 def _next_one_time_alarm_times(
@@ -333,6 +428,33 @@ class ScheduledRoutineAlarmMixin:
         else:
             self._replace_alarms(
                 [{**alarm, **alarm_wake_time_update_payload(alarm, wake_time)}]
+            )
+        self.publish_updates()
+
+    async def set_alarm_weekdays(
+        self,
+        alarm_id: int | str,
+        weekdays: Iterable[str],
+    ) -> None:
+        alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            await self.refresh_alarms()
+            alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            raise ValueError(f"Alarm {alarm_id} not found for {self.device_name}")
+
+        api, auth_token = self._configured_alarm_api()
+        updated_alarms = await api.update_scheduled_routine_alarm_weekdays(
+            auth_token=auth_token,
+            mac=self.mac,
+            alarm=alarm,
+            weekdays=weekdays,
+        )
+        if updated_alarms:
+            self._replace_alarms(updated_alarms)
+        else:
+            self._replace_alarms(
+                [{**alarm, **alarm_weekdays_update_payload(alarm, weekdays)}]
             )
         self.publish_updates()
 

--- a/src/hatch_rest_api/scheduled_routine.py
+++ b/src/hatch_rest_api/scheduled_routine.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 if TYPE_CHECKING:
@@ -34,8 +34,12 @@ def alarm_update_payload(
         raise ValueError("Cannot update alarm without an id")
 
     start_time = alarm.get("startTime")
+    end_time = alarm.get("endTime")
     if enabled and _is_one_time_alarm(alarm):
-        start_time = _next_one_time_start_time(start_time, now=now)
+        start_time, end_time = _next_one_time_alarm_times(
+            alarm,
+            now=now,
+        )
 
     return {
         "id": alarm["id"],
@@ -44,7 +48,49 @@ def alarm_update_payload(
         "enabled": enabled,
         "displayOrder": alarm.get("displayOrder"),
         "startTime": start_time,
-        "endTime": alarm.get("endTime"),
+        "endTime": end_time,
+    }
+
+
+def alarm_wake_time_update_payload(
+    alarm: ScheduledRoutineAlarm,
+    wake_time: time,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if "id" not in alarm:
+        raise ValueError("Cannot update alarm without an id")
+
+    start_time = alarm.get("startTime")
+    end_time = alarm.get("endTime")
+    parsed_start_time = _parse_required_local_datetime(start_time, "startTime")
+    wake_time = wake_time.replace(tzinfo=None)
+
+    parsed_end_time = _parse_local_datetime(end_time)
+    if parsed_end_time is None and end_time is not None:
+        raise ValueError("Cannot update alarm wake time without a valid endTime")
+
+    sunrise_lead = _alarm_sunrise_lead(alarm, parsed_start_time, parsed_end_time)
+    if _is_one_time_alarm(alarm):
+        updated_end_time = _next_datetime_for_time(wake_time, now=now)
+    elif parsed_end_time is not None:
+        updated_end_time = datetime.combine(parsed_end_time.date(), wake_time)
+    else:
+        existing_wake_time = parsed_start_time + sunrise_lead
+        updated_end_time = datetime.combine(existing_wake_time.date(), wake_time)
+    updated_start_time = updated_end_time - sunrise_lead
+
+    return {
+        "id": alarm["id"],
+        "name": alarm.get("name"),
+        "active": alarm.get("active"),
+        "enabled": alarm.get("enabled"),
+        "displayOrder": alarm.get("displayOrder"),
+        "startTime": _format_like_original(start_time, updated_start_time),
+        "endTime": (
+            _format_like_original(end_time, updated_end_time)
+            if end_time is not None
+            else None
+        ),
     }
 
 
@@ -61,44 +107,150 @@ def _is_one_time_alarm(alarm: ScheduledRoutineAlarm) -> bool:
     return days_of_week is None or days_of_week == 0
 
 
-def _next_one_time_start_time(
-    start_time: str | None,
+def _next_one_time_alarm_times(
+    alarm: ScheduledRoutineAlarm,
     now: datetime | None = None,
-) -> str | None:
-    if not isinstance(start_time, str):
-        return start_time
-
+) -> tuple[str | None, str | None]:
+    start_time = alarm.get("startTime")
+    end_time = alarm.get("endTime")
     parsed_start_time = _parse_local_datetime(start_time)
+    parsed_end_time = _parse_local_datetime(end_time)
+    if parsed_end_time is not None:
+        next_end_time = _next_datetime_for_time(parsed_end_time.time(), now=now)
+        if parsed_start_time is None:
+            return start_time, _format_like_original(end_time, next_end_time)
+        next_start_time = next_end_time - (parsed_end_time - parsed_start_time)
+        return (
+            _format_like_original(start_time, next_start_time),
+            _format_like_original(end_time, next_end_time),
+        )
+
     if parsed_start_time is None:
-        return start_time
+        return start_time, end_time
+
+    if end_time is None:
+        sunrise_duration = _alarm_sunrise_duration_seconds(alarm)
+        if sunrise_duration is not None:
+            sunrise_lead = timedelta(seconds=sunrise_duration)
+            current_wake_time = parsed_start_time + sunrise_lead
+            next_end_time = _next_datetime_for_time(
+                current_wake_time.time(),
+                now=now,
+            )
+            next_start_time = next_end_time - sunrise_lead
+            return _format_like_original(start_time, next_start_time), end_time
+
+    next_start_time = _next_datetime_for_time(parsed_start_time.time(), now=now)
+    return _format_like_original(start_time, next_start_time), end_time
+
+
+def _alarm_sunrise_lead(
+    alarm: ScheduledRoutineAlarm,
+    parsed_start_time: datetime,
+    parsed_end_time: datetime | None,
+) -> timedelta:
+    if parsed_end_time is not None:
+        return parsed_end_time - parsed_start_time
+
+    sunrise_duration = _alarm_sunrise_duration_seconds(alarm)
+    if sunrise_duration is None:
+        raise ValueError(
+            "Cannot update alarm wake time without a valid sunrise duration"
+        )
+    return timedelta(seconds=sunrise_duration)
+
+
+def _alarm_sunrise_duration_seconds(alarm: ScheduledRoutineAlarm) -> int | None:
+    steps = alarm.get("steps") or []
+    sunrise_step_duration = next(
+        (
+            duration
+            for step in steps
+            if isinstance(step, dict)
+            and str(step.get("name", "")).lower() == "sunrise"
+            and (duration := _step_color_duration_seconds(step)) is not None
+        ),
+        None,
+    )
+    if sunrise_step_duration is not None:
+        return sunrise_step_duration
+
+    return next(
+        (
+            duration
+            for step in steps
+            if isinstance(step, dict)
+            and (duration := _step_color_duration_seconds(step)) is not None
+        ),
+        None,
+    )
+
+
+def _step_color_duration_seconds(step: dict[str, Any]) -> int | None:
+    if step.get("enabled") is False:
+        return None
+
+    color = step.get("color")
+    if not isinstance(color, dict) or color.get("ignore") is True:
+        return None
+
+    duration = color.get("duration")
+    if isinstance(duration, bool) or not isinstance(duration, int) or duration <= 0:
+        return None
+
+    return duration
+
+
+def _next_datetime_for_time(
+    value: time,
+    now: datetime | None = None,
+) -> datetime:
+    value = value.replace(tzinfo=None)
 
     if now is None:
         now = datetime.now()
-    if parsed_start_time.tzinfo is not None:
-        parsed_start_time = parsed_start_time.replace(tzinfo=None)
     if now.tzinfo is not None:
         now = now.replace(tzinfo=None)
 
-    next_start_time = datetime.combine(now.date(), parsed_start_time.time())
-    if next_start_time <= now:
-        next_start_time = next_start_time + timedelta(days=1)
+    next_time = datetime.combine(now.date(), value)
+    if next_time <= now:
+        next_time = next_time + timedelta(days=1)
 
-    return _format_like_original(start_time, next_start_time)
+    return next_time
 
 
 def _parse_local_datetime(value: str) -> datetime | None:
+    if not isinstance(value, str):
+        return None
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
+    if parsed.tzinfo is not None:
+        return parsed.replace(tzinfo=None)
+    return parsed
 
 
-def _format_like_original(original: str, value: datetime) -> str:
+def _parse_required_local_datetime(value: str | None, field: str) -> datetime:
+    parsed = _parse_local_datetime(value)
+    if parsed is None:
+        raise ValueError(f"Cannot update alarm wake time without a valid {field}")
+    return parsed
+
+
+def _format_like_original(original: str | None, value: datetime) -> str:
+    if not isinstance(original, str):
+        return value.isoformat(timespec="seconds")
     if "." in original:
-        return value.isoformat()
-    if len(original.split("T", 1)[-1].split(":")) <= 2:
-        return value.isoformat(timespec="minutes")
-    return value.isoformat(timespec="seconds")
+        formatted = value.isoformat()
+    elif len(original.split("T", 1)[-1].split(":")) <= 2:
+        formatted = value.isoformat(timespec="minutes")
+    else:
+        formatted = value.isoformat(timespec="seconds")
+
+    if "T" not in original and " " in original:
+        return formatted.replace("T", " ", 1)
+    return formatted
 
 
 class ScheduledRoutineAlarmMixin:
@@ -159,6 +311,29 @@ class ScheduledRoutineAlarmMixin:
             self._replace_alarms(updated_alarms)
         else:
             alarm["enabled"] = enabled
+        self.publish_updates()
+
+    async def set_alarm_wake_time(self, alarm_id: int | str, wake_time: time) -> None:
+        alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            await self.refresh_alarms()
+            alarm = self.alarm_by_id(alarm_id)
+        if alarm is None:
+            raise ValueError(f"Alarm {alarm_id} not found for {self.device_name}")
+
+        api, auth_token = self._configured_alarm_api()
+        updated_alarms = await api.update_scheduled_routine_alarm_wake_time(
+            auth_token=auth_token,
+            mac=self.mac,
+            alarm=alarm,
+            wake_time=wake_time,
+        )
+        if updated_alarms:
+            self._replace_alarms(updated_alarms)
+        else:
+            self._replace_alarms(
+                [{**alarm, **alarm_wake_time_update_payload(alarm, wake_time)}]
+            )
         self.publish_updates()
 
     def _configured_alarm_api(self) -> tuple["Hatch", str]:

--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -4,7 +4,7 @@ from functools import partial
 from re import IGNORECASE, sub
 from uuid import uuid4
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from awscrt import io
 from awscrt.auth import AwsCredentialsProvider
 from awsiot.iotshadow import IotShadowClient
@@ -23,6 +23,7 @@ from .rest_plus import RestPlus
 from .restore_iot import RestoreIot
 from .restore_v4 import RestoreV4
 from .restore_v5 import RestoreV5
+from .scheduled_routine import ALARM_ROUTINE_TYPE, ScheduledRoutineAlarmMixin
 from .types import SimpleSoundContent
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,6 +50,9 @@ async def get_rest_devices(
     aws_token = await api.token(auth_token=token)
     favorites_map = await _get_favorites_for_all_v2_devices(api, token, iot_devices)
     routines_map = await _get_routines_for_all_v2_devices(api, token, iot_devices)
+    alarms_map = await _get_alarms_for_all_scheduled_routine_devices(
+        api, token, iot_devices
+    )
     sounds_map = await _get_sound_content_for_all_v2_devices(
         api, token, contentful, iot_devices
     )
@@ -93,6 +97,11 @@ async def get_rest_devices(
 
     shadow_client = IotShadowClient(mqtt_connection)
 
+    def _with_alarm_api(rest_device, alarms):
+        if isinstance(rest_device, ScheduledRoutineAlarmMixin):
+            rest_device.configure_alarm_api(api=api, auth_token=token, alarms=alarms)
+        return rest_device
+
     def create_rest_devices(iot_device):
         mac_address = iot_device["macAddress"]
         if mac_address in favorites_map:
@@ -105,6 +114,11 @@ async def get_rest_devices(
         else:
             _LOGGER.debug(f"Iot device {iot_device} has no routines")
             routines = []
+        if mac_address in alarms_map:
+            alarms = list(alarms_map[mac_address])
+        else:
+            _LOGGER.debug(f"Iot device {iot_device} has no alarms")
+            alarms = []
         if iot_device["product"] == "restPlus":
             return RestPlus(
                 device_name=iot_device["name"],
@@ -122,31 +136,40 @@ async def get_rest_devices(
                 sounds=sounds_map[mac_address],
             )
         elif iot_device["product"] == "restoreIot":
-            return RestoreIot(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=routines + favorites,
-                sounds=sounds_map[mac_address],
+            return _with_alarm_api(
+                RestoreIot(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=routines + favorites,
+                    sounds=sounds_map[mac_address],
+                ),
+                alarms,
             )
         elif iot_device["product"] == "restoreV4":
-            return RestoreV4(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=routines + favorites,
-                sounds=sounds_map[mac_address],
+            return _with_alarm_api(
+                RestoreV4(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=routines + favorites,
+                    sounds=sounds_map[mac_address],
+                ),
+                alarms,
             )
         elif iot_device["product"] == "restoreV5":
-            return RestoreV5(
-                device_name=iot_device["name"],
-                thing_name=iot_device["thingName"],
-                mac=mac_address,
-                shadow_client=shadow_client,
-                favorites=routines + favorites,
-                sounds=sounds_map[mac_address],
+            return _with_alarm_api(
+                RestoreV5(
+                    device_name=iot_device["name"],
+                    thing_name=iot_device["thingName"],
+                    mac=mac_address,
+                    shadow_client=shadow_client,
+                    favorites=routines + favorites,
+                    sounds=sounds_map[mac_address],
+                ),
+                alarms,
             )
         elif iot_device["product"] == "restBaby":
             return RestBaby(
@@ -194,6 +217,29 @@ async def _get_routines_for_all_v2_devices(api, token, iot_devices):
             _LOGGER.debug(f"Routines for {mac}: {routines}")
             mac_to_routines[mac] = routines
     return mac_to_routines
+
+
+async def _get_alarms_for_all_scheduled_routine_devices(api, token, iot_devices):
+    mac_to_alarms = {}
+    for device in iot_devices:
+        if device["product"] in ["restoreIot", "restoreV4", "restoreV5"]:
+            mac = device["macAddress"]
+            try:
+                alarms = await api.scheduled_routines(
+                    auth_token=token,
+                    mac=mac,
+                    types=[ALARM_ROUTINE_TYPE],
+                )
+            except RateError:
+                raise
+            except ClientError as e:
+                _LOGGER.warning(
+                    f"Could not fetch alarm routines for {mac}: {str(e)}"
+                )
+                alarms = None
+            _LOGGER.debug(f"Alarms for {mac}: {alarms}")
+            mac_to_alarms[mac] = alarms
+    return mac_to_alarms
 
 
 async def _get_sound_content_for_all_v2_devices(

--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -23,7 +23,11 @@ from .rest_plus import RestPlus
 from .restore_iot import RestoreIot
 from .restore_v4 import RestoreV4
 from .restore_v5 import RestoreV5
-from .scheduled_routine import ALARM_ROUTINE_TYPE, ScheduledRoutineAlarmMixin
+from .scheduled_routine import (
+    ALARM_ROUTINE_TYPE,
+    SCHEDULED_ROUTINE_ALARM_PRODUCTS,
+    ScheduledRoutineAlarmMixin,
+)
 from .types import SimpleSoundContent
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,7 +119,7 @@ async def get_rest_devices(
             _LOGGER.debug(f"Iot device {iot_device} has no routines")
             routines = []
         if mac_address in alarms_map:
-            alarms = list(alarms_map[mac_address])
+            alarms = alarms_map[mac_address]
         else:
             _LOGGER.debug(f"Iot device {iot_device} has no alarms")
             alarms = []
@@ -222,7 +226,7 @@ async def _get_routines_for_all_v2_devices(api, token, iot_devices):
 async def _get_alarms_for_all_scheduled_routine_devices(api, token, iot_devices):
     mac_to_alarms = {}
     for device in iot_devices:
-        if device["product"] in ["restoreIot", "restoreV4", "restoreV5"]:
+        if device["product"] in SCHEDULED_ROUTINE_ALARM_PRODUCTS:
             mac = device["macAddress"]
             try:
                 alarms = await api.scheduled_routines(

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -4,8 +4,12 @@ from datetime import datetime, time
 from hatch_rest_api.hatch import Hatch
 from hatch_rest_api.scheduled_routine import (
     SCHEDULED_ROUTINE_ALARM_PRODUCTS,
+    alarm_weekdays_update_payload,
     alarm_update_payload,
     alarm_wake_time_update_payload,
+    days_of_week_label,
+    days_of_week_to_weekdays,
+    weekdays_to_days_of_week,
 )
 
 
@@ -53,44 +57,48 @@ class FakeSession:
         self.calls.append(("POST", url, headers, json))
         if url.endswith("/service/app/routine/v2/editMultiple"):
             self.last_mrds = json["mrds"]
+            item = {
+                "id": json["mrds"][0]["id"],
+                "name": json["mrds"][0]["name"],
+                "active": json["mrds"][0]["active"],
+                "enabled": json["mrds"][0]["enabled"],
+                "type": "alarm",
+                "macAddress": "AA:BB:CC",
+                "startTime": json["mrds"][0]["startTime"],
+                "endTime": json["mrds"][0]["endTime"],
+            }
+            if "daysOfWeek" in json["mrds"][0]:
+                item["daysOfWeek"] = json["mrds"][0]["daysOfWeek"]
             return FakeResponse(
                 url,
                 {
                     "status": "success",
                     "payload": {
                         "confirmDataVersion": True,
-                        "item": [
-                            {
-                                "id": json["mrds"][0]["id"],
-                                "name": json["mrds"][0]["name"],
-                                "active": json["mrds"][0]["active"],
-                                "enabled": json["mrds"][0]["enabled"],
-                                "type": "alarm",
-                                "macAddress": "AA:BB:CC",
-                                "startTime": json["mrds"][0]["startTime"],
-                                "endTime": json["mrds"][0]["endTime"],
-                            }
-                        ],
+                        "item": [item],
                         "dataVersion": "version-1",
                     },
                 },
             )
+        item = {
+            "id": self.last_mrds[0]["id"],
+            "name": self.last_mrds[0]["name"],
+            "active": self.last_mrds[0]["active"],
+            "enabled": self.last_mrds[0]["enabled"],
+            "type": "alarm",
+            "macAddress": "AA:BB:CC",
+            "startTime": self.last_mrds[0]["startTime"],
+            "endTime": self.last_mrds[0]["endTime"],
+        }
+        if "daysOfWeek" in self.last_mrds[0]:
+            item["daysOfWeek"] = self.last_mrds[0]["daysOfWeek"]
         return FakeResponse(
             url,
             {
                 "status": "success",
                 "payload": [
                     {"id": 5, "type": "routine", "enabled": True},
-                    {
-                        "id": self.last_mrds[0]["id"],
-                        "name": self.last_mrds[0]["name"],
-                        "active": self.last_mrds[0]["active"],
-                        "enabled": self.last_mrds[0]["enabled"],
-                        "type": "alarm",
-                        "macAddress": "AA:BB:CC",
-                        "startTime": self.last_mrds[0]["startTime"],
-                        "endTime": self.last_mrds[0]["endTime"],
-                    },
+                    item,
                 ],
             },
         )
@@ -124,6 +132,76 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
         self.assertEqual(payload["displayOrder"], 7)
         self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
         self.assertEqual(payload["endTime"], "2026-05-08T08:00:00")
+
+    def test_weekdays_to_days_of_week_converts_weekday_lists_to_bitmask(self):
+        self.assertEqual(
+            weekdays_to_days_of_week(["monday", "tuesday", "friday"]),
+            38,
+        )
+        self.assertEqual(weekdays_to_days_of_week([]), 0)
+        self.assertEqual(
+            weekdays_to_days_of_week([" Sunday ", "SATURDAY"]),
+            65,
+        )
+
+    def test_days_of_week_to_weekdays_and_label_convert_bitmask(self):
+        self.assertEqual(
+            days_of_week_to_weekdays(38),
+            ["monday", "tuesday", "friday"],
+        )
+        self.assertEqual(days_of_week_to_weekdays(0), [])
+        self.assertEqual(days_of_week_label(0), "Once")
+        self.assertEqual(days_of_week_label(62), "Weekdays")
+        self.assertEqual(days_of_week_label(65), "Weekends")
+        self.assertEqual(days_of_week_label(127), "Every day")
+        self.assertEqual(days_of_week_label(42), "Mon, Wed, Fri")
+
+    def test_alarm_weekdays_update_payload_preserves_fields_and_updates_days(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": False,
+            "enabled": True,
+            "displayOrder": 7,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": "2026-05-08T08:00:00",
+            "daysOfWeek": 127,
+        }
+
+        payload = alarm_weekdays_update_payload(alarm, ["monday", "friday"])
+
+        self.assertEqual(payload["id"], 2)
+        self.assertEqual(payload["name"], "Wake")
+        self.assertIs(payload["active"], False)
+        self.assertIs(payload["enabled"], True)
+        self.assertEqual(payload["displayOrder"], 7)
+        self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(payload["endTime"], "2026-05-08T08:00:00")
+        self.assertEqual(payload["daysOfWeek"], 34)
+
+    def test_alarm_weekdays_update_payload_allows_one_time_alarm(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": True,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": "2026-05-08T08:00:00",
+            "daysOfWeek": 127,
+        }
+
+        payload = alarm_weekdays_update_payload(alarm, [])
+
+        self.assertEqual(payload["daysOfWeek"], 0)
+        self.assertIs(payload["enabled"], True)
+        self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(payload["endTime"], "2026-05-08T08:00:00")
+
+    def test_alarm_weekdays_update_payload_rejects_invalid_weekday(self):
+        alarm = {"id": 2}
+
+        with self.assertRaisesRegex(ValueError, "Unsupported alarm weekday"):
+            alarm_weekdays_update_payload(alarm, ["funday"])
 
     def test_one_time_alarm_enable_rolls_wake_time_to_tomorrow_when_time_passed(self):
         alarm = {
@@ -414,6 +492,60 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertIs(edit_body["mrds"][0]["enabled"], False)
         self.assertEqual(edit_body["mrds"][0]["startTime"], "2026-05-08T07:45:00")
         self.assertEqual(edit_body["mrds"][0]["endTime"], "2026-05-08T08:15:00")
+
+    async def test_alarm_weekdays_update_uses_edit_multiple_and_confirms_data_version(self):
+        session = FakeSession()
+        api = Hatch(client_session=session)
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "type": "alarm",
+            "macAddress": "AA:BB:CC",
+            "displayOrder": 1,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": "2026-05-08T08:00:00",
+            "daysOfWeek": 127,
+        }
+
+        updated = await api.update_scheduled_routine_alarm_weekdays(
+            auth_token="token",
+            mac="AA:BB:CC",
+            alarm=alarm,
+            weekdays=["monday", "tuesday", "friday"],
+        )
+
+        self.assertEqual(updated, [
+            {
+                "id": 2,
+                "name": "Wake",
+                "active": True,
+                "enabled": False,
+                "type": "alarm",
+                "macAddress": "AA:BB:CC",
+                "startTime": "2026-05-08T07:30:00",
+                "endTime": "2026-05-08T08:00:00",
+                "daysOfWeek": 38,
+            }
+        ])
+        _, edit_url, _, edit_body = session.calls[0]
+        self.assertTrue(edit_url.endswith("/service/app/routine/v2/editMultiple"))
+        self.assertEqual(edit_body["type"], "alarm")
+        self.assertIs(edit_body["mrds"][0]["active"], True)
+        self.assertIs(edit_body["mrds"][0]["enabled"], False)
+        self.assertEqual(edit_body["mrds"][0]["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(edit_body["mrds"][0]["endTime"], "2026-05-08T08:00:00")
+        self.assertEqual(edit_body["mrds"][0]["daysOfWeek"], 38)
+
+        _, confirm_url, _, confirm_body = session.calls[1]
+        self.assertTrue(confirm_url.endswith("/service/app/v2/dataVersion"))
+        self.assertEqual(confirm_body, {
+            "dataVersion": "version-1",
+            "macAddress": "AA:BB:CC",
+            "success": True,
+            "returnAllRoutines": True,
+        })
 
 
 if __name__ == "__main__":

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -2,7 +2,10 @@ import unittest
 from datetime import datetime
 
 from hatch_rest_api.hatch import Hatch
-from hatch_rest_api.scheduled_routine import alarm_update_payload
+from hatch_rest_api.scheduled_routine import (
+    SCHEDULED_ROUTINE_ALARM_PRODUCTS,
+    alarm_update_payload,
+)
 
 
 class FakeResponse:
@@ -87,6 +90,12 @@ class FakeSession:
 
 
 class ScheduledRoutineAlarmTest(unittest.TestCase):
+    def test_alarm_products_include_all_restore_generations(self):
+        self.assertEqual(
+            SCHEDULED_ROUTINE_ALARM_PRODUCTS,
+            {"restoreIot", "restoreV4", "restoreV5"},
+        )
+
     def test_alarm_update_payload_preserves_active_and_toggles_enabled(self):
         alarm = {
             "id": 2,

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -120,6 +120,21 @@ class EmptyAlarmUpdateApi:
         return []
 
 
+class RefreshAlarmApi:
+    def __init__(self, alarms: list[dict]):
+        self.alarms = alarms
+        self.calls = []
+
+    async def scheduled_routines(
+        self,
+        auth_token: str,
+        mac: str,
+        types: list[str],
+    ):
+        self.calls.append((auth_token, mac, types))
+        return list(self.alarms)
+
+
 class FakeAlarmDevice(ScheduledRoutineAlarmMixin):
     mac = "AA:BB:CC"
     device_name = "Restore"
@@ -588,6 +603,33 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
 
 
 class ScheduledRoutineAlarmMixinTest(unittest.IsolatedAsyncioTestCase):
+    async def test_failed_initial_fetch_remains_alarm_capable_for_refresh(self):
+        api = RefreshAlarmApi(
+            [
+                {
+                    "id": 2,
+                    "name": "Wake",
+                    "type": "alarm",
+                    "macAddress": "AA:BB:CC",
+                }
+            ]
+        )
+        device = FakeAlarmDevice()
+
+        device.configure_alarm_api(api=api, auth_token="token", alarms=None)
+
+        self.assertIs(device.alarm_capable, True)
+        self.assertIs(device.alarms_loaded, False)
+        self.assertEqual(device.alarms, [])
+
+        refreshed = await device.refresh_alarms()
+
+        self.assertEqual(api.calls, [("token", "AA:BB:CC", ["alarm"])])
+        self.assertIs(device.alarms_loaded, True)
+        self.assertEqual(refreshed, api.alarms)
+        self.assertEqual(device.alarms, api.alarms)
+        self.assertEqual(device.publish_count, 1)
+
     async def test_set_alarm_enabled_fallback_rolls_one_time_alarm_times(self):
         api = EmptyAlarmUpdateApi()
         device = FakeAlarmDevice()

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -119,6 +119,16 @@ class EmptyAlarmUpdateApi:
         self.calls.append((auth_token, mac, alarm["id"], enabled))
         return []
 
+    async def update_scheduled_routine_alarm_weekdays(
+        self,
+        auth_token: str,
+        mac: str,
+        alarm: dict,
+        weekdays,
+    ):
+        self.calls.append((auth_token, mac, alarm["id"], list(weekdays)))
+        return []
+
 
 class RefreshAlarmApi:
     def __init__(self, alarms: list[dict]):
@@ -665,6 +675,41 @@ class ScheduledRoutineAlarmMixinTest(unittest.IsolatedAsyncioTestCase):
         updated_end = datetime.fromisoformat(updated_alarm["endTime"])
         self.assertGreater(updated_end, before_update)
         self.assertEqual((updated_end - updated_start).total_seconds(), 1800)
+
+
+    async def test_set_alarm_weekdays_accepts_generator_input(self):
+        api = EmptyAlarmUpdateApi()
+        device = FakeAlarmDevice()
+        device.configure_alarm_api(
+            api=api,
+            auth_token="token",
+            alarms=[
+                {
+                    "id": 2,
+                    "name": "Wake",
+                    "active": True,
+                    "enabled": True,
+                    "type": "alarm",
+                    "macAddress": "AA:BB:CC",
+                    "startTime": "2026-05-08T07:30:00",
+                    "endTime": "2026-05-08T08:00:00",
+                    "daysOfWeek": 0,
+                }
+            ],
+        )
+
+        await device.set_alarm_weekdays(
+            2,
+            (weekday for weekday in ["monday", "wednesday", "friday"]),
+        )
+
+        self.assertEqual(
+            api.calls,
+            [("token", "AA:BB:CC", 2, ["monday", "wednesday", "friday"])],
+        )
+        self.assertEqual(device.publish_count, 1)
+        updated_alarm = device.alarms[0]
+        self.assertEqual(updated_alarm["daysOfWeek"], 42)
 
 
 if __name__ == "__main__":

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -1,10 +1,11 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, time
 
 from hatch_rest_api.hatch import Hatch
 from hatch_rest_api.scheduled_routine import (
     SCHEDULED_ROUTINE_ALARM_PRODUCTS,
     alarm_update_payload,
+    alarm_wake_time_update_payload,
 )
 
 
@@ -26,6 +27,7 @@ class FakeResponse:
 class FakeSession:
     def __init__(self):
         self.calls = []
+        self.last_mrds = []
 
     async def get(self, url: str, headers: dict, params: dict):
         self.calls.append(("GET", url, headers, params))
@@ -50,6 +52,7 @@ class FakeSession:
     async def post(self, url: str, json: dict, headers: dict):
         self.calls.append(("POST", url, headers, json))
         if url.endswith("/service/app/routine/v2/editMultiple"):
+            self.last_mrds = json["mrds"]
             return FakeResponse(
                 url,
                 {
@@ -64,6 +67,8 @@ class FakeSession:
                                 "enabled": json["mrds"][0]["enabled"],
                                 "type": "alarm",
                                 "macAddress": "AA:BB:CC",
+                                "startTime": json["mrds"][0]["startTime"],
+                                "endTime": json["mrds"][0]["endTime"],
                             }
                         ],
                         "dataVersion": "version-1",
@@ -77,12 +82,14 @@ class FakeSession:
                 "payload": [
                     {"id": 5, "type": "routine", "enabled": True},
                     {
-                        "id": 2,
-                        "name": "Wake",
-                        "active": True,
-                        "enabled": False,
+                        "id": self.last_mrds[0]["id"],
+                        "name": self.last_mrds[0]["name"],
+                        "active": self.last_mrds[0]["active"],
+                        "enabled": self.last_mrds[0]["enabled"],
                         "type": "alarm",
                         "macAddress": "AA:BB:CC",
+                        "startTime": self.last_mrds[0]["startTime"],
+                        "endTime": self.last_mrds[0]["endTime"],
                     },
                 ],
             },
@@ -104,7 +111,7 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
             "enabled": True,
             "displayOrder": 7,
             "startTime": "2026-05-08T07:30:00",
-            "endTime": None,
+            "endTime": "2026-05-08T08:00:00",
             "daysOfWeek": 127,
         }
 
@@ -116,14 +123,16 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
         self.assertIs(payload["enabled"], False)
         self.assertEqual(payload["displayOrder"], 7)
         self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(payload["endTime"], "2026-05-08T08:00:00")
 
-    def test_one_time_alarm_rolls_to_tomorrow_when_time_passed(self):
+    def test_one_time_alarm_enable_rolls_wake_time_to_tomorrow_when_time_passed(self):
         alarm = {
             "id": 2,
             "name": "Wake",
             "active": True,
             "enabled": False,
-            "startTime": "2026-05-08T07:30:00",
+            "startTime": "2026-05-08T07:00:00",
+            "endTime": "2026-05-08T07:30:00",
             "daysOfWeek": 0,
         }
 
@@ -133,15 +142,17 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
             now=datetime(2026, 5, 8, 8, 0, 0),
         )
 
-        self.assertEqual(payload["startTime"], "2026-05-09T07:30:00")
+        self.assertEqual(payload["startTime"], "2026-05-09T07:00:00")
+        self.assertEqual(payload["endTime"], "2026-05-09T07:30:00")
 
-    def test_one_time_alarm_rolls_to_today_when_time_is_future(self):
+    def test_one_time_alarm_enable_rolls_wake_time_to_today_when_time_is_future(self):
         alarm = {
             "id": 2,
             "name": "Wake",
             "active": True,
             "enabled": False,
-            "startTime": "2026-05-07T07:30:00",
+            "startTime": "2026-05-07T07:00:00",
+            "endTime": "2026-05-07T07:30:00",
             "daysOfWeek": 0,
         }
 
@@ -151,7 +162,143 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
             now=datetime(2026, 5, 8, 6, 0, 0),
         )
 
-        self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(payload["startTime"], "2026-05-08T07:00:00")
+        self.assertEqual(payload["endTime"], "2026-05-08T07:30:00")
+
+    def test_wake_time_update_preserves_sunrise_lead_for_repeating_alarm(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "displayOrder": 3,
+            "startTime": "2026-05-08T07:00:00",
+            "endTime": "2026-05-08T07:30:00",
+            "daysOfWeek": 127,
+        }
+
+        payload = alarm_wake_time_update_payload(alarm, time(8, 15))
+
+        self.assertEqual(payload["id"], 2)
+        self.assertEqual(payload["name"], "Wake")
+        self.assertIs(payload["active"], True)
+        self.assertIs(payload["enabled"], False)
+        self.assertEqual(payload["displayOrder"], 3)
+        self.assertEqual(payload["startTime"], "2026-05-08T07:45:00")
+        self.assertEqual(payload["endTime"], "2026-05-08T08:15:00")
+
+    def test_wake_time_update_rolls_one_time_alarm_to_next_occurrence(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08T07:00:00",
+            "endTime": "2026-05-08T07:30:00",
+            "daysOfWeek": 0,
+        }
+
+        payload = alarm_wake_time_update_payload(
+            alarm,
+            time(6, 45),
+            now=datetime(2026, 5, 8, 8, 0, 0),
+        )
+
+        self.assertEqual(payload["startTime"], "2026-05-09T06:15:00")
+        self.assertEqual(payload["endTime"], "2026-05-09T06:45:00")
+
+    def test_wake_time_update_uses_sunrise_duration_when_end_time_is_missing(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08T10:45:00",
+            "endTime": None,
+            "daysOfWeek": 62,
+            "steps": [
+                {
+                    "name": "Sunrise",
+                    "enabled": True,
+                    "color": {"duration": 2700, "ignore": False},
+                }
+            ],
+        }
+
+        payload = alarm_wake_time_update_payload(alarm, time(11, 15))
+
+        self.assertEqual(payload["startTime"], "2026-05-08T10:30:00")
+        self.assertIsNone(payload["endTime"])
+        self.assertIs(payload["enabled"], False)
+
+    def test_one_time_alarm_enable_uses_sunrise_duration_when_end_time_is_missing(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08 10:45:00",
+            "endTime": None,
+            "daysOfWeek": 0,
+            "steps": [
+                {
+                    "name": "Sunrise",
+                    "enabled": True,
+                    "color": {"duration": 2700, "ignore": False},
+                }
+            ],
+        }
+
+        payload = alarm_update_payload(
+            alarm,
+            True,
+            now=datetime(2026, 5, 8, 12, 0, 0),
+        )
+
+        self.assertEqual(payload["startTime"], "2026-05-09 10:45:00")
+        self.assertIsNone(payload["endTime"])
+
+    def test_wake_time_update_requires_sunrise_duration_when_end_time_is_missing(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08T10:45:00",
+            "endTime": None,
+            "daysOfWeek": 62,
+        }
+
+        with self.assertRaisesRegex(ValueError, "valid sunrise duration"):
+            alarm_wake_time_update_payload(alarm, time(11, 15))
+
+    def test_wake_time_update_requires_valid_start_time(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "not-a-date",
+            "endTime": "2026-05-08T07:30:00",
+            "daysOfWeek": 127,
+        }
+
+        with self.assertRaisesRegex(ValueError, "valid startTime"):
+            alarm_wake_time_update_payload(alarm, time(6, 45))
+
+    def test_wake_time_update_requires_valid_end_time_when_end_time_is_present(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08T07:00:00",
+            "endTime": "not-a-date",
+            "daysOfWeek": 127,
+        }
+
+        with self.assertRaisesRegex(ValueError, "valid endTime"):
+            alarm_wake_time_update_payload(alarm, time(6, 45))
 
 
 class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
@@ -184,7 +331,7 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
             "macAddress": "AA:BB:CC",
             "displayOrder": 1,
             "startTime": "2026-05-08T07:30:00",
-            "endTime": None,
+            "endTime": "2026-05-08T08:00:00",
             "daysOfWeek": 127,
         }
 
@@ -203,6 +350,8 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
                 "enabled": False,
                 "type": "alarm",
                 "macAddress": "AA:BB:CC",
+                "startTime": "2026-05-08T07:30:00",
+                "endTime": "2026-05-08T08:00:00",
             }
         ])
         _, edit_url, _, edit_body = session.calls[0]
@@ -211,6 +360,8 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(edit_body["mrds"][0]["id"], 2)
         self.assertIs(edit_body["mrds"][0]["active"], True)
         self.assertIs(edit_body["mrds"][0]["enabled"], False)
+        self.assertEqual(edit_body["mrds"][0]["startTime"], "2026-05-08T07:30:00")
+        self.assertEqual(edit_body["mrds"][0]["endTime"], "2026-05-08T08:00:00")
 
         _, confirm_url, _, confirm_body = session.calls[1]
         self.assertTrue(confirm_url.endswith("/service/app/v2/dataVersion"))
@@ -220,6 +371,49 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
             "success": True,
             "returnAllRoutines": True,
         })
+
+    async def test_alarm_wake_time_update_uses_edit_multiple_and_preserves_enabled(self):
+        session = FakeSession()
+        api = Hatch(client_session=session)
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "type": "alarm",
+            "macAddress": "AA:BB:CC",
+            "displayOrder": 1,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": "2026-05-08T08:00:00",
+            "daysOfWeek": 127,
+        }
+
+        updated = await api.update_scheduled_routine_alarm_wake_time(
+            auth_token="token",
+            mac="AA:BB:CC",
+            alarm=alarm,
+            wake_time=time(8, 15),
+        )
+
+        self.assertEqual(updated, [
+            {
+                "id": 2,
+                "name": "Wake",
+                "active": True,
+                "enabled": False,
+                "type": "alarm",
+                "macAddress": "AA:BB:CC",
+                "startTime": "2026-05-08T07:45:00",
+                "endTime": "2026-05-08T08:15:00",
+            }
+        ])
+        _, edit_url, _, edit_body = session.calls[0]
+        self.assertTrue(edit_url.endswith("/service/app/routine/v2/editMultiple"))
+        self.assertEqual(edit_body["type"], "alarm")
+        self.assertIs(edit_body["mrds"][0]["active"], True)
+        self.assertIs(edit_body["mrds"][0]["enabled"], False)
+        self.assertEqual(edit_body["mrds"][0]["startTime"], "2026-05-08T07:45:00")
+        self.assertEqual(edit_body["mrds"][0]["endTime"], "2026-05-08T08:15:00")
 
 
 if __name__ == "__main__":

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -149,6 +149,18 @@ class ScheduledRoutineAlarmTest(unittest.TestCase):
             days_of_week_to_weekdays(38),
             ["monday", "tuesday", "friday"],
         )
+        self.assertEqual(
+            days_of_week_to_weekdays(127),
+            [
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+                "sunday",
+            ],
+        )
         self.assertEqual(days_of_week_to_weekdays(0), [])
         self.assertEqual(days_of_week_label(0), "Once")
         self.assertEqual(days_of_week_label(62), "Weekdays")

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -1,0 +1,217 @@
+import unittest
+from datetime import datetime
+
+from hatch_rest_api.hatch import Hatch
+from hatch_rest_api.scheduled_routine import alarm_update_payload
+
+
+class FakeResponse:
+    status = 200
+    headers = {}
+
+    def __init__(self, url: str, payload: dict):
+        self.url = url
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+    async def text(self):
+        return str(self._payload)
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def get(self, url: str, headers: dict, params: dict):
+        self.calls.append(("GET", url, headers, params))
+        return FakeResponse(
+            url,
+            {
+                "status": "success",
+                "payload": [
+                    {
+                        "id": 2,
+                        "name": "Wake",
+                        "active": True,
+                        "enabled": True,
+                        "type": "alarm",
+                        "macAddress": "AA:BB:CC",
+                        "displayOrder": 1,
+                    }
+                ],
+            },
+        )
+
+    async def post(self, url: str, json: dict, headers: dict):
+        self.calls.append(("POST", url, headers, json))
+        if url.endswith("/service/app/routine/v2/editMultiple"):
+            return FakeResponse(
+                url,
+                {
+                    "status": "success",
+                    "payload": {
+                        "confirmDataVersion": True,
+                        "item": [
+                            {
+                                "id": json["mrds"][0]["id"],
+                                "name": json["mrds"][0]["name"],
+                                "active": json["mrds"][0]["active"],
+                                "enabled": json["mrds"][0]["enabled"],
+                                "type": "alarm",
+                                "macAddress": "AA:BB:CC",
+                            }
+                        ],
+                        "dataVersion": "version-1",
+                    },
+                },
+            )
+        return FakeResponse(
+            url,
+            {
+                "status": "success",
+                "payload": [
+                    {"id": 5, "type": "routine", "enabled": True},
+                    {
+                        "id": 2,
+                        "name": "Wake",
+                        "active": True,
+                        "enabled": False,
+                        "type": "alarm",
+                        "macAddress": "AA:BB:CC",
+                    },
+                ],
+            },
+        )
+
+
+class ScheduledRoutineAlarmTest(unittest.TestCase):
+    def test_alarm_update_payload_preserves_active_and_toggles_enabled(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": False,
+            "enabled": True,
+            "displayOrder": 7,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": None,
+            "daysOfWeek": 127,
+        }
+
+        payload = alarm_update_payload(alarm, False)
+
+        self.assertEqual(payload["id"], 2)
+        self.assertEqual(payload["name"], "Wake")
+        self.assertIs(payload["active"], False)
+        self.assertIs(payload["enabled"], False)
+        self.assertEqual(payload["displayOrder"], 7)
+        self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+
+    def test_one_time_alarm_rolls_to_tomorrow_when_time_passed(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-08T07:30:00",
+            "daysOfWeek": 0,
+        }
+
+        payload = alarm_update_payload(
+            alarm,
+            True,
+            now=datetime(2026, 5, 8, 8, 0, 0),
+        )
+
+        self.assertEqual(payload["startTime"], "2026-05-09T07:30:00")
+
+    def test_one_time_alarm_rolls_to_today_when_time_is_future(self):
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": False,
+            "startTime": "2026-05-07T07:30:00",
+            "daysOfWeek": 0,
+        }
+
+        payload = alarm_update_payload(
+            alarm,
+            True,
+            now=datetime(2026, 5, 8, 6, 0, 0),
+        )
+
+        self.assertEqual(payload["startTime"], "2026-05-08T07:30:00")
+
+
+class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
+    async def test_scheduled_routine_fetch_uses_v3_alarm_query(self):
+        session = FakeSession()
+        api = Hatch(client_session=session)
+
+        routines = await api.scheduled_routines(
+            auth_token="token",
+            mac="AA:BB:CC",
+            types=["alarm"],
+        )
+
+        self.assertEqual(routines[0]["id"], 2)
+        method, url, headers, params = session.calls[0]
+        self.assertEqual(method, "GET")
+        self.assertTrue(url.endswith("/service/app/routine/v3/fetch"))
+        self.assertEqual(headers["X-HatchBaby-Auth"], "token")
+        self.assertEqual(params, {"macAddress": "AA:BB:CC", "types": ["alarm"]})
+
+    async def test_alarm_update_uses_edit_multiple_and_confirms_data_version(self):
+        session = FakeSession()
+        api = Hatch(client_session=session)
+        alarm = {
+            "id": 2,
+            "name": "Wake",
+            "active": True,
+            "enabled": True,
+            "type": "alarm",
+            "macAddress": "AA:BB:CC",
+            "displayOrder": 1,
+            "startTime": "2026-05-08T07:30:00",
+            "endTime": None,
+            "daysOfWeek": 127,
+        }
+
+        updated = await api.update_scheduled_routine_alarm_enabled(
+            auth_token="token",
+            mac="AA:BB:CC",
+            alarm=alarm,
+            enabled=False,
+        )
+
+        self.assertEqual(updated, [
+            {
+                "id": 2,
+                "name": "Wake",
+                "active": True,
+                "enabled": False,
+                "type": "alarm",
+                "macAddress": "AA:BB:CC",
+            }
+        ])
+        _, edit_url, _, edit_body = session.calls[0]
+        self.assertTrue(edit_url.endswith("/service/app/routine/v2/editMultiple"))
+        self.assertEqual(edit_body["type"], "alarm")
+        self.assertEqual(edit_body["mrds"][0]["id"], 2)
+        self.assertIs(edit_body["mrds"][0]["active"], True)
+        self.assertIs(edit_body["mrds"][0]["enabled"], False)
+
+        _, confirm_url, _, confirm_body = session.calls[1]
+        self.assertTrue(confirm_url.endswith("/service/app/v2/dataVersion"))
+        self.assertEqual(confirm_body, {
+            "dataVersion": "version-1",
+            "macAddress": "AA:BB:CC",
+            "success": True,
+            "returnAllRoutines": True,
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduled_routine.py
+++ b/tests/test_scheduled_routine.py
@@ -4,6 +4,7 @@ from datetime import datetime, time
 from hatch_rest_api.hatch import Hatch
 from hatch_rest_api.scheduled_routine import (
     SCHEDULED_ROUTINE_ALARM_PRODUCTS,
+    ScheduledRoutineAlarmMixin,
     alarm_weekdays_update_payload,
     alarm_update_payload,
     alarm_wake_time_update_payload,
@@ -102,6 +103,32 @@ class FakeSession:
                 ],
             },
         )
+
+
+class EmptyAlarmUpdateApi:
+    def __init__(self):
+        self.calls = []
+
+    async def update_scheduled_routine_alarm_enabled(
+        self,
+        auth_token: str,
+        mac: str,
+        alarm: dict,
+        enabled: bool,
+    ):
+        self.calls.append((auth_token, mac, alarm["id"], enabled))
+        return []
+
+
+class FakeAlarmDevice(ScheduledRoutineAlarmMixin):
+    mac = "AA:BB:CC"
+    device_name = "Restore"
+
+    def __init__(self):
+        self.publish_count = 0
+
+    def publish_updates(self):
+        self.publish_count += 1
 
 
 class ScheduledRoutineAlarmTest(unittest.TestCase):
@@ -558,6 +585,44 @@ class HatchScheduledRoutineApiTest(unittest.IsolatedAsyncioTestCase):
             "success": True,
             "returnAllRoutines": True,
         })
+
+
+class ScheduledRoutineAlarmMixinTest(unittest.IsolatedAsyncioTestCase):
+    async def test_set_alarm_enabled_fallback_rolls_one_time_alarm_times(self):
+        api = EmptyAlarmUpdateApi()
+        device = FakeAlarmDevice()
+        device.configure_alarm_api(
+            api=api,
+            auth_token="token",
+            alarms=[
+                {
+                    "id": 2,
+                    "name": "Wake",
+                    "active": True,
+                    "enabled": False,
+                    "type": "alarm",
+                    "macAddress": "AA:BB:CC",
+                    "startTime": "2000-01-01T07:00:00",
+                    "endTime": "2000-01-01T07:30:00",
+                    "daysOfWeek": 0,
+                }
+            ],
+        )
+        before_update = datetime.now()
+
+        await device.set_alarm_enabled(2, True)
+
+        self.assertEqual(api.calls, [("token", "AA:BB:CC", 2, True)])
+        self.assertEqual(device.publish_count, 1)
+        updated_alarm = device.alarms[0]
+        self.assertIs(updated_alarm["enabled"], True)
+        self.assertEqual(updated_alarm["daysOfWeek"], 0)
+        self.assertNotEqual(updated_alarm["startTime"], "2000-01-01T07:00:00")
+        self.assertNotEqual(updated_alarm["endTime"], "2000-01-01T07:30:00")
+        updated_start = datetime.fromisoformat(updated_alarm["startTime"])
+        updated_end = datetime.fromisoformat(updated_alarm["endTime"])
+        self.assertGreater(updated_end, before_update)
+        self.assertEqual((updated_end - updated_start).total_seconds(), 1800)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds alarm support! This PR fetches alarms via `/routine/v3/fetch?type=alarm` and does what it needs to support dahlb/ha_hatch#298.