### PR TITLE
feat: Restore 3 routine controls (advance, swap, pause, resume, snooze, stop)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,8 @@ keywords = [
 [project.urls]
 "Homepage" = "https://github.com/dahlb/hatch_rest_api"
 "Bug Tracker" = "https://github.com/dahlb/hatch_rest_api/issues"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/src/hatch_rest_api/hatch.py
+++ b/src/hatch_rest_api/hatch.py
@@ -272,6 +272,54 @@ class Hatch:
 
         return updated_routines
 
+    async def bulk_edit_swappables(
+        self,
+        auth_token: str,
+        mac: str,
+        routines: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        url = API_URL + "service/app/routine/v2/bulkEditSwappables"
+        response: ClientResponse = (
+            await self._post_request_with_logging_and_errors_raised(
+                url=url,
+                auth_token=auth_token,
+                json_body={"routines": routines},
+            )
+        )
+        response_json = await response.json()
+        payload = response_json["payload"]
+        item = payload.get("item") if isinstance(payload, dict) else None
+        if item:
+            return item
+
+        if (
+            isinstance(payload, dict)
+            and payload.get("confirmDataVersion")
+            and payload.get("dataVersion")
+        ):
+            try:
+                confirmed = await self.confirm_data_version(
+                    auth_token=auth_token,
+                    mac=mac,
+                    data_version=payload["dataVersion"],
+                    success=True,
+                    return_all_routines=True,
+                )
+                if confirmed:
+                    return [
+                        dict(routine)
+                        for routine in confirmed
+                        if routine.get("type") == "routine"
+                    ]
+            except ClientError as error:
+                _LOGGER.warning(
+                    "Could not confirm bulk swappable data version for %s; "
+                    "returning best-effort payload",
+                    mac,
+                    exc_info=error,
+                )
+        return item or []
+
     async def edit_scheduled_routines(
         self,
         auth_token: str,

--- a/src/hatch_rest_api/restore_v5.py
+++ b/src/hatch_rest_api/restore_v5.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from .types import SoundContent, SimpleSoundContent
 from .util import (
@@ -29,6 +30,7 @@ class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
     current_playing: str = "none"
     current_id: int = 0
     current_step: int = 0
+    paused: bool = False
     color_id: int = NO_COLOR_ID
     sound_id: int = NO_SOUND_ID
     red: int = 0
@@ -39,6 +41,9 @@ class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
     clock_nighttime: int = 0
     clock_daytime: int = 0
     flags: int = 0
+    is_snoozed: bool = False
+    snooze_start_time: str = ""
+    snooze_duration_seconds: int = 540
 
     def _update_local_state(self, state):
         _LOGGER.debug(f"update local state: {self.device_name}, {state}")
@@ -50,8 +55,16 @@ class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
             self.current_id = safely_get_json_value(state, "current.srId")
         if safely_get_json_value(state, "current.step") is not None:
             self.current_step = safely_get_json_value(state, "current.step")
+        if safely_get_json_value(state, "current.paused") is not None:
+            self.paused = safely_get_json_value(state, "current.paused", bool)
         if safely_get_json_value(state, "connected") is not None:
             self.is_online = safely_get_json_value(state, "connected", bool)
+        if safely_get_json_value(state, "snooze.active") is not None:
+            self.is_snoozed = safely_get_json_value(state, "snooze.active", bool)
+        if safely_get_json_value(state, "snooze.startTime") is not None:
+            self.snooze_start_time = safely_get_json_value(state, "snooze.startTime")
+        if safely_get_json_value(state, "snoozeDuration") is not None:
+            self.snooze_duration_seconds = safely_get_json_value(state, "snoozeDuration", int)
         if safely_get_json_value(state, "current.sound.v") is not None:
             self.volume = convert_to_percentage(
                 safely_get_json_value(state, "current.sound.v", int)
@@ -98,6 +111,10 @@ class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
             "current_playing": self.current_playing,
             "current_id": self.current_id,
             "current_step": self.current_step,
+            "paused": self.paused,
+            "is_snoozed": self.is_snoozed,
+            "snooze_start_time": self.snooze_start_time,
+            "snooze_duration_seconds": self.snooze_duration_seconds,
             "is_on": self.is_on,
             "is_playing": self.is_playing,
             "sound_id": self.sound_id,
@@ -173,6 +190,128 @@ class RestoreV5(ScheduledRoutineAlarmMixin, ShadowClientSubscriberMixin):
         _LOGGER.debug(f"Setting favorite: {favorite_name_id}")
         fav_id = int(favorite_name_id.rsplit("-", 1)[1])
         self._update({"current": {"srId": fav_id, "step": 1, "playing": "routine"}})
+
+    def stop_routine(self):
+        self.turn_off()
+
+    @property
+    def _playing_routine(self) -> dict | None:
+        if self.current_playing != "routine":
+            return None
+        return next(
+            (f for f in self.favorites if f.get("id") == self.current_id),
+            None,
+        )
+
+    @property
+    def routine_step_count(self) -> int:
+        routine = self._playing_routine
+        if routine is None:
+            return 0
+        return len(routine.get("steps") or [])
+
+    @property
+    def can_advance_step(self) -> bool:
+        return self.current_step + 1 < self.routine_step_count
+
+    @property
+    def swappable_routines(self) -> list[dict]:
+        return sorted(
+            (
+                f for f in self.favorites
+                if f.get("button0") and f.get("type") == "routine"
+            ),
+            key=lambda r: (r.get("displayOrder") if r.get("displayOrder") is not None else float("inf")),
+        )
+
+    @property
+    def can_swap_routine(self) -> bool:
+        return len(self.swappable_routines) > 1
+
+    def advance_step(self):
+        if self.current_playing != "routine":
+            _LOGGER.debug("advance_step ignored, no routine playing")
+            return
+        if self.paused:
+            _LOGGER.debug("advance_step ignored, routine is paused")
+            return
+        steps_count = self.routine_step_count
+        if steps_count == 0:
+            _LOGGER.debug("advance_step ignored, no step data for current routine")
+            return
+        next_step = self.current_step + 1
+        if next_step >= steps_count:
+            _LOGGER.debug(f"advance_step ignored, already at last step {self.current_step}/{steps_count - 1}")
+            return
+        _LOGGER.debug(f"Advancing routine to step {next_step}")
+        self._update({"current": {"step": next_step}})
+
+    async def swap_routine(self):
+        if self._alarm_api is None or self._alarm_auth_token is None:
+            raise RuntimeError(f"{self.device_name} REST API is not configured")
+        swappables = self.swappable_routines
+        if len(swappables) <= 1:
+            _LOGGER.debug("swap_routine ignored, fewer than 2 swappable routines")
+            return
+        active_index = next(
+            (i for i, r in enumerate(swappables) if r.get("active")),
+            None,
+        )
+        if active_index is None:
+            active_index = 0
+        next_index = (active_index + 1) % len(swappables)
+        if active_index == next_index:
+            return
+        active_routine = swappables[active_index]
+        next_routine = swappables[next_index]
+        _LOGGER.debug(
+            f"Swapping active routine from {active_routine.get('id')} to {next_routine.get('id')}"
+        )
+        routines_to_edit = [
+            {**active_routine, "active": False},
+            {**next_routine, "active": True},
+        ]
+        updated = await self._alarm_api.bulk_edit_swappables(
+            auth_token=self._alarm_auth_token,
+            mac=self.mac,
+            routines=routines_to_edit,
+        )
+        if updated:
+            updated_by_id = {r["id"]: r for r in updated if r.get("id") is not None}
+            self.favorites = [
+                {**f, **updated_by_id[f["id"]]} if f.get("id") in updated_by_id else f
+                for f in self.favorites
+            ]
+        else:
+            local_by_id = {
+                active_routine["id"]: {**active_routine, "active": False},
+                next_routine["id"]: {**next_routine, "active": True},
+            }
+            self.favorites = [
+                {**f, **local_by_id[f["id"]]} if f.get("id") in local_by_id else f
+                for f in self.favorites
+            ]
+        self.publish_updates()
+
+    def pause_routine(self):
+        if self.current_playing != "routine":
+            _LOGGER.debug("pause_routine ignored, no routine playing")
+            return
+        if self.paused:
+            return
+        _LOGGER.debug("Pausing routine")
+        self._update({"current": {"paused": True}})
+
+    def resume_routine(self):
+        if not self.paused:
+            return
+        _LOGGER.debug("Resuming routine")
+        self._update({"current": {"paused": False}})
+
+    def snooze_alarm(self):
+        start_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        _LOGGER.debug(f"Snoozing alarm at {start_time}")
+        self._update({"snooze": {"active": True, "startTime": start_time}})
 
     def set_sound(self, sound_or_id_or_title: SoundContent | SimpleSoundContent | str | int | None, duration: int = 0, until="indefinite"):
         """

--- a/tests/test_restore_v5.py
+++ b/tests/test_restore_v5.py
@@ -1,0 +1,260 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock
+
+from hatch_rest_api.restore_v5 import RestoreV5
+
+
+class FakeRestoreV5(RestoreV5):
+    def __init__(self):
+        self._updates: list[dict] = []
+        self._published = 0
+        self.current_playing = "none"
+        self.current_id = 0
+        self.current_step = 0
+        self.paused = False
+        self.is_snoozed = False
+        self.favorites: list[dict] = []
+        self.device_name = "Fake Restore"
+        self.mac = "AA:BB:CC:DD:EE:FF"
+        self._alarm_api = None
+        self._alarm_auth_token = None
+
+    def _update(self, desired_state):
+        self._updates.append(desired_state)
+
+    def publish_updates(self):
+        self._published += 1
+
+
+class RestoreV5RoutineControlTest(unittest.TestCase):
+    def test_stop_routine_writes_same_payload_as_turn_off(self):
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+        device.current_step = 3
+
+        device.stop_routine()
+
+        self.assertEqual(
+            device._updates,
+            [{"current": {"srId": 0, "step": 0, "playing": "none"}}],
+        )
+
+    def test_pause_routine_writes_paused_true_when_routine_playing(self):
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+
+        device.pause_routine()
+
+        self.assertEqual(device._updates, [{"current": {"paused": True}}])
+
+    def test_pause_routine_is_noop_when_no_routine_playing(self):
+        device = FakeRestoreV5()
+        device.current_playing = "none"
+
+        device.pause_routine()
+
+        self.assertEqual(device._updates, [])
+
+    def test_pause_routine_is_noop_when_already_paused(self):
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+        device.paused = True
+
+        device.pause_routine()
+
+        self.assertEqual(device._updates, [])
+
+    def test_resume_routine_writes_paused_false_when_paused(self):
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+        device.paused = True
+
+        device.resume_routine()
+
+        self.assertEqual(device._updates, [{"current": {"paused": False}}])
+
+    def test_resume_routine_is_noop_when_not_paused(self):
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+        device.paused = False
+
+        device.resume_routine()
+
+        self.assertEqual(device._updates, [])
+
+    def test_snooze_alarm_writes_active_true_with_start_time(self):
+        device = FakeRestoreV5()
+
+        device.snooze_alarm()
+
+        self.assertEqual(len(device._updates), 1)
+        update = device._updates[0]
+        self.assertIn("snooze", update)
+        self.assertEqual(update["snooze"]["active"], True)
+        # startTime is "YYYY-MM-DD HH:MM:SS" — 19 chars
+        start_time = update["snooze"]["startTime"]
+        self.assertEqual(len(start_time), 19)
+        self.assertEqual(start_time[4], "-")
+        self.assertEqual(start_time[7], "-")
+        self.assertEqual(start_time[10], " ")
+        self.assertEqual(start_time[13], ":")
+        self.assertEqual(start_time[16], ":")
+
+
+class RestoreV5AdvanceStepTest(unittest.TestCase):
+    def _device_with_routine(self, *, steps: int, current_step: int = 0) -> FakeRestoreV5:
+        device = FakeRestoreV5()
+        device.current_playing = "routine"
+        device.current_id = 42
+        device.current_step = current_step
+        device.favorites = [
+            {
+                "id": 42,
+                "type": "routine",
+                "steps": [{"name": f"step{i}"} for i in range(steps)],
+            }
+        ]
+        return device
+
+    def test_advance_step_writes_next_step(self):
+        device = self._device_with_routine(steps=3, current_step=1)
+
+        device.advance_step()
+
+        self.assertEqual(device._updates, [{"current": {"step": 2}}])
+
+    def test_advance_step_noop_when_at_last_step(self):
+        device = self._device_with_routine(steps=3, current_step=2)
+
+        device.advance_step()
+
+        self.assertEqual(device._updates, [])
+
+    def test_advance_step_noop_when_no_routine_playing(self):
+        device = self._device_with_routine(steps=3, current_step=0)
+        device.current_playing = "none"
+
+        device.advance_step()
+
+        self.assertEqual(device._updates, [])
+
+    def test_advance_step_noop_when_paused(self):
+        device = self._device_with_routine(steps=3, current_step=0)
+        device.paused = True
+
+        device.advance_step()
+
+        self.assertEqual(device._updates, [])
+
+    def test_advance_step_noop_when_routine_has_no_steps(self):
+        device = self._device_with_routine(steps=0, current_step=0)
+
+        device.advance_step()
+
+        self.assertEqual(device._updates, [])
+
+    def test_can_advance_step_reflects_remaining_steps(self):
+        device = self._device_with_routine(steps=3, current_step=0)
+        self.assertTrue(device.can_advance_step)
+        device.current_step = 2
+        self.assertFalse(device.can_advance_step)
+
+
+class RestoreV5SwapRoutineTest(unittest.TestCase):
+    def _device_with_swappables(self, active_id: int | None = 10) -> FakeRestoreV5:
+        device = FakeRestoreV5()
+        device.favorites = [
+            {"id": 10, "type": "routine", "button0": True, "displayOrder": 0, "active": active_id == 10},
+            {"id": 20, "type": "routine", "button0": True, "displayOrder": 1, "active": active_id == 20},
+            {"id": 30, "type": "routine", "button0": True, "displayOrder": 2, "active": active_id == 30},
+            {"id": 99, "type": "routine", "button0": False, "displayOrder": 3, "active": False},
+        ]
+        device._alarm_auth_token = "token"
+        return device
+
+    def test_swappable_routines_filters_and_sorts(self):
+        device = self._device_with_swappables()
+        ids = [r["id"] for r in device.swappable_routines]
+        self.assertEqual(ids, [10, 20, 30])
+
+    def test_can_swap_routine_requires_more_than_one(self):
+        device = self._device_with_swappables()
+        self.assertTrue(device.can_swap_routine)
+        device.favorites = [device.favorites[0]]
+        self.assertTrue(device.can_swap_routine is False)
+
+    def test_swap_routine_advances_to_next_swappable(self):
+        device = self._device_with_swappables(active_id=10)
+        api = AsyncMock()
+        api.bulk_edit_swappables = AsyncMock(
+            return_value=[
+                {"id": 10, "active": False},
+                {"id": 20, "active": True},
+            ]
+        )
+        device._alarm_api = api
+
+        asyncio.run(device.swap_routine())
+
+        api.bulk_edit_swappables.assert_awaited_once()
+        kwargs = api.bulk_edit_swappables.await_args.kwargs
+        self.assertEqual(kwargs["auth_token"], "token")
+        self.assertEqual(kwargs["mac"], device.mac)
+        self.assertEqual(
+            [(r["id"], r["active"]) for r in kwargs["routines"]],
+            [(10, False), (20, True)],
+        )
+        active_ids = [f["id"] for f in device.favorites if f.get("active")]
+        self.assertEqual(active_ids, [20])
+
+    def test_swap_routine_wraps_around(self):
+        device = self._device_with_swappables(active_id=30)
+        api = AsyncMock()
+        api.bulk_edit_swappables = AsyncMock(return_value=[])
+        device._alarm_api = api
+
+        asyncio.run(device.swap_routine())
+
+        kwargs = api.bulk_edit_swappables.await_args.kwargs
+        self.assertEqual(
+            [(r["id"], r["active"]) for r in kwargs["routines"]],
+            [(30, False), (10, True)],
+        )
+        active_ids = [f["id"] for f in device.favorites if f.get("active")]
+        self.assertEqual(active_ids, [10])
+
+    def test_swap_routine_noop_when_only_one_swappable(self):
+        device = self._device_with_swappables()
+        device.favorites = [device.favorites[0]]
+        api = AsyncMock()
+        device._alarm_api = api
+
+        asyncio.run(device.swap_routine())
+
+        api.bulk_edit_swappables.assert_not_called()
+
+    def test_swap_routine_raises_when_api_not_configured(self):
+        device = self._device_with_swappables()
+        device._alarm_api = None
+
+        with self.assertRaises(RuntimeError):
+            asyncio.run(device.swap_routine())
+
+    def test_swap_routine_falls_back_to_first_when_none_active(self):
+        device = self._device_with_swappables(active_id=None)
+        api = AsyncMock()
+        api.bulk_edit_swappables = AsyncMock(return_value=[])
+        device._alarm_api = api
+
+        asyncio.run(device.swap_routine())
+
+        kwargs = api.bulk_edit_swappables.await_args.kwargs
+        self.assertEqual(
+            [(r["id"], r["active"]) for r in kwargs["routines"]],
+            [(10, False), (20, True)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the routine-control surface that the Restore 3's three on-device buttons expose, so Home Assistant automations can drive (and be driven by) the same gestures the physical buttons do.

- **`advance_step`** — Big Button single-press while a routine is playing. Writes `current.step` to the AWS IoT shadow, gated by step count from the cached favorites payload.
- **`swap_routine`** — Swap button. Async; flips the active swappable routine via the new `Hatch.bulk_edit_swappables()` REST call against `/service/app/routine/v2/bulkEditSwappables`, with `confirmDataVersion` follow-up on the envelope.
- **`pause_routine` / `resume_routine`** — Pause button toggle, writes `current.paused`. Tracks the inbound `current.paused` shadow value.
- **`snooze_alarm`** — Big Button while an alarm sounds. Writes `snooze.active=true` with `startTime`. Surfaces `is_snoozed`, `snooze_start_time`, `snooze_duration_seconds` from the shadow.
- **`stop_routine`** — Big Button long-press, alias for `turn_off()`.

Helpers `swappable_routines`, `can_swap_routine`, `routine_step_count`, `can_advance_step`, `_playing_routine` are exposed so the integration can gate button availability cleanly.

The shadow keys (`current.step`, `current.paused`, `snooze.active`, `snooze.startTime`) and the `bulkEditSwappables` REST endpoint were derived from APK reverse engineering of the Hatch Sleep Android app (v6.13.2).

## Test plan

- [x] `uv run pytest tests/test_restore_v5.py -v` — 20 tests, all pass
- [ ] End-to-end on a real Restore 3 via the companion `ha_hatch` PR: physical Big Button advance / Swap / Pause / Resume mirror behavior of the new methods
- [ ] Verify `bulkEditSwappables` payload shape (full ScheduledRoutine echoed back) matches what Hatch's API actually accepts — the field-name inference may surface a mismatch on first real call