### PR TITLE
fix: add timeout to mqtt connect to avoid indefinite hang

### DIFF
--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -32,6 +32,11 @@ from .types import SimpleSoundContent
 
 _LOGGER = logging.getLogger(__name__)
 
+# Seconds to wait for the MQTT connection to establish before giving up.
+# Prevents thread pool workers from blocking indefinitely when the Hatch
+# cloud is unreachable in ways that don't fail fast (e.g. hung TCP).
+MQTT_CONNECT_TIMEOUT = 30
+
 io.init_logging(io.LogLevel.NoLogs, "stderr")
 
 
@@ -93,7 +98,9 @@ async def get_rest_devices(
     )
     try:
         connect_future = await loop.run_in_executor(None, mqtt_connection.connect)
-        await loop.run_in_executor(None, connect_future.result)
+        await loop.run_in_executor(
+            None, partial(connect_future.result, MQTT_CONNECT_TIMEOUT)
+        )
         _LOGGER.debug("mqtt connection connected")
     except Exception as e:
         _LOGGER.error(f"MQTT connection failed with exception {e}")


### PR DESCRIPTION
## Summary

`get_rest_devices` waits on the MQTT connect future with no timeout:

```python
connect_future = await loop.run_in_executor(None, mqtt_connection.connect)
await loop.run_in_executor(None, connect_future.result)
```

If the Hatch cloud is unreachable in a way that doesn't fail fast (hung TCP, half-open connection during an outage), `connect_future.result` blocks its executor thread and the awaiting coroutine forever. In the ha_hatch integration this manifests as config entry setup hanging indefinitely during Hatch cloud outages.

This applies the same fix as #60 did for the shadow client operations: a bounded wait (30 s) that raises `concurrent.futures.TimeoutError`, which propagates through the existing `except` block in `get_rest_devices` so callers can retry with backoff.

## Context

During a Hatch cloud outage on 2026-07-24 this hang (together with a companion bug in ha_hatch, PR incoming there) repeatedly locked up a Home Assistant instance from ~4:41 AM until the integration was disabled.

## Testing

- `pytest tests/` — 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUv54T1tjc6TJYCsUXyPE2