### PR TITLE
fix: reuse a shared awscrt ClientBootstrap to stop event loop thread leak

### DIFF
--- a/src/hatch_rest_api/util_bootstrap.py
+++ b/src/hatch_rest_api/util_bootstrap.py
@@ -40,6 +40,24 @@ MQTT_CONNECT_TIMEOUT = 30
 io.init_logging(io.LogLevel.NoLogs, "stderr")
 
 
+def _get_client_bootstrap():
+    """Return the process-wide ClientBootstrap used for every MQTT connection.
+
+    awscrt starts a native event loop thread per EventLoopGroup and only stops
+    it when the native resource is destroyed. Nothing here ever destroys one:
+    the shadow subscriptions set up per device hold callbacks that reference
+    the device, which references the connection, which owns the bootstrap, so
+    the whole graph stays reachable even after ``disconnect()``. Building a
+    group per call therefore stranded a thread, its pipe pair and its CRT
+    buffers every time.
+
+    Callers rebuild the connection whenever the AWS credentials expire, which
+    Hatch issues hourly, so that cost accumulated for as long as the process
+    ran. Sharing awscrt's static default keeps it flat at one thread.
+    """
+    return io.ClientBootstrap.get_or_create_static_default()
+
+
 async def get_rest_devices(
     email: str,
     password: str,
@@ -77,9 +95,7 @@ async def get_rest_devices(
         aws_credentials["Credentials"]["SecretKey"],
         session_token=aws_credentials["Credentials"]["SessionToken"],
     )
-    event_loop_group = io.EventLoopGroup(1)
-    host_resolver = io.DefaultHostResolver(event_loop_group)
-    client_bootstrap = io.ClientBootstrap(event_loop_group, host_resolver)
+    client_bootstrap = _get_client_bootstrap()
     endpoint = aws_token["endpoint"].lstrip("https://")
     safe_email = sub("[^a-z]", "", email, flags=IGNORECASE).lower()
     mqtt_connection = await loop.run_in_executor(

--- a/tests/test_util_bootstrap.py
+++ b/tests/test_util_bootstrap.py
@@ -61,6 +61,71 @@ class FakeShadowClient:
         return lambda *args, **kwargs: MagicMock()
 
 
+def _run_bootstrap(io_mock=None):
+    """Run get_rest_devices with every network dependency faked.
+
+    Returns the patched connection builder and the patched awscrt ``io`` module
+    so tests can assert on how each was used. Pass an ``io_mock`` to share one
+    across several runs, which is how a reconnect is simulated.
+    """
+    builder = MagicMock(return_value=MagicMock())
+    if io_mock is None:
+        io_mock = MagicMock()
+
+    with (
+        patch.object(util_bootstrap, "Hatch", FakeHatch),
+        patch.object(util_bootstrap, "Contentful", MagicMock()),
+        patch.object(util_bootstrap, "AwsHttp", FakeAwsHttp),
+        patch.object(util_bootstrap, "AwsCredentialsProvider", MagicMock()),
+        patch.object(util_bootstrap, "io", io_mock),
+        patch.object(
+            util_bootstrap, "IotShadowClient", lambda *a, **kw: FakeShadowClient()
+        ),
+        patch.object(util_bootstrap, "websockets_with_default_aws_signing", builder),
+    ):
+        asyncio.run(
+            util_bootstrap.get_rest_devices(
+                email="user@example.com", password="hunter2"
+            )
+        )
+
+    return builder, io_mock
+
+
+class GetRestDevicesClientBootstrapTest(unittest.TestCase):
+    """Regression guard for the awscrt event loop thread leak.
+
+    ``get_rest_devices`` used to build an EventLoopGroup, DefaultHostResolver
+    and ClientBootstrap of its own on every call. awscrt starts a native thread
+    per EventLoopGroup and only stops it once the native resource is destroyed,
+    which never happened while the connection graph stayed reachable. Since
+    callers reconnect every time the AWS credentials expire -- hourly -- each
+    refresh stranded another thread, pipe pair and set of CRT buffers.
+    """
+
+    def test_uses_shared_static_bootstrap(self):
+        _, io_mock = _run_bootstrap()
+
+        io_mock.ClientBootstrap.get_or_create_static_default.assert_called_once()
+
+    def test_does_not_build_per_connection_event_loop_group(self):
+        _, io_mock = _run_bootstrap()
+
+        io_mock.EventLoopGroup.assert_not_called()
+        io_mock.DefaultHostResolver.assert_not_called()
+
+    def test_reconnects_reuse_the_same_bootstrap(self):
+        io_mock = MagicMock()
+        builder_one, _ = _run_bootstrap(io_mock)
+        builder_two, _ = _run_bootstrap(io_mock)
+
+        self.assertIs(
+            builder_one.call_args.kwargs["client_bootstrap"],
+            builder_two.call_args.kwargs["client_bootstrap"],
+        )
+        io_mock.EventLoopGroup.assert_not_called()
+
+
 class GetRestDevicesMetricsTest(unittest.TestCase):
     """Regression guard for dahlb/ha_hatch#323.
 
@@ -76,38 +141,14 @@ class GetRestDevicesMetricsTest(unittest.TestCase):
     keep passing enable_metrics_collection=False so that path is never entered.
     """
 
-    def _run_bootstrap(self):
-        builder = MagicMock(return_value=MagicMock())
-
-        with (
-            patch.object(util_bootstrap, "Hatch", FakeHatch),
-            patch.object(util_bootstrap, "Contentful", MagicMock()),
-            patch.object(util_bootstrap, "AwsHttp", FakeAwsHttp),
-            patch.object(util_bootstrap, "AwsCredentialsProvider", MagicMock()),
-            patch.object(util_bootstrap, "io", MagicMock()),
-            patch.object(
-                util_bootstrap, "IotShadowClient", lambda *a, **kw: FakeShadowClient()
-            ),
-            patch.object(
-                util_bootstrap, "websockets_with_default_aws_signing", builder
-            ),
-        ):
-            asyncio.run(
-                util_bootstrap.get_rest_devices(
-                    email="user@example.com", password="hunter2"
-                )
-            )
-
-        return builder
-
     def test_metrics_collection_disabled(self):
-        builder = self._run_bootstrap()
+        builder, _ = _run_bootstrap()
 
         builder.assert_called_once()
         self.assertIs(builder.call_args.kwargs["enable_metrics_collection"], False)
 
     def test_devices_still_created(self):
-        builder = self._run_bootstrap()
+        builder, _ = _run_bootstrap()
 
         # Sanity check that disabling metrics did not disturb the rest of the
         # bootstrap: the connection is still built and devices still returned.


### PR DESCRIPTION
## Summary

`get_rest_devices()` built a fresh `io.EventLoopGroup(1)` + `DefaultHostResolver` +
`ClientBootstrap` on every call. awscrt starts a native thread per `EventLoopGroup`
and only stops it when the native resource is destroyed. Nothing in the shutdown
path ever destroys it: each device's shadow subscriptions hold callbacks that
reference the device, which references the connection, which owns the bootstrap —
so the whole graph stays reachable even after `disconnect()`.

Home Assistant's `ha_hatch` integration rebuilds this connection every time the
AWS credentials expire, which Hatch issues hourly, so a long-running instance
strands one `EventLoopGroup` thread per hour indefinitely. Measured on my own
instance: 215 leaked `AwsEventLoop` threads after 8.7 days of uptime, an exact
match for the reconnect count, costing roughly 80 MB/day.

Fix: use `io.ClientBootstrap.get_or_create_static_default()`, awscrt's own
process-wide default, instead of allocating a new one per call.

## Test plan

- 3 new regression tests asserting the shared bootstrap is used, no
  `EventLoopGroup`/`DefaultHostResolver` are built per call, and a second
  connection reuses the same bootstrap instance. All fail against the
  pre-fix code (`AttributeError`/mock-call-count mismatches), confirming
  they aren't vacuous.
- Full suite passes: 28/28 (32/32 once the follow-up PR #TBD is included).
- Deployed to my own Home Assistant via a `git+https` requirement pointed at
  this branch and soaked in production. `AwsEventLoop` thread count held flat
  at 2 across 137 hours of uptime (vs. 215 pre-fix over 8.7 days), and open fds
  stayed flat at 72-77 (vs. 434 pre-fix).

There is a second, independent leak in the same area — shadow subscriptions are
never unsubscribed, so the Python-side connection graph also outlives
`disconnect()`. That's a separate PR on top of this branch, since the two are
independently reviewable and this one already has its own soak evidence.